### PR TITLE
Fix focus delegation for term inputs

### DIFF
--- a/src/term-highlight.ts
+++ b/src/term-highlight.ts
@@ -1846,6 +1846,9 @@ const getTermsFromSelection = () => {
 						});
 						return; // Focus is being moved, not lost.
 					}
+					if (document.activeElement && document.activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+						return;
+					}
 					bar.removeEventListener("focusout", returnSelection);
 					if (focusReturnElement && focusReturnElement["focus"]) {
 						(focusReturnElement as HTMLElement).focus({ preventScroll: true });


### PR DESCRIPTION
* Prevent focus from being returned to previous active element on unfocusing the option menu