### PR TITLE
Add highlight stepping

### DIFF
--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -81,28 +81,34 @@
 			"description": "Enable/disable sticky term jumping mode"
 		},
 		"focus-term-append": {
-			"description": "Focus the input for appending a term"
+			"description": "Focus input for appending a term"
+		},
+		"step-global": {
+			"description": "Step to and select next highlight"
+		},
+		"step-global-reverse": {
+			"description": "Step to and select previous highlight"
 		},
 		"advance-global": {
 			"suggested_key": { "default": "Alt+Space" },
-			"description": "Jump to next mark in page"
+			"description": "Jump to next highlight block"
 		},
 		"advance-global-reverse": {
 			"suggested_key": { "default": "Alt+Shift+Space" },
-			"description": "Jump to previous mark in page"
+			"description": "Jump to previous highlight block"
 		},
-		"select-term-0": { "description": "Jump to next for 1st term" },
-		"select-term-1": { "description": "Jump to next for 2nd term" },
-		"select-term-2": { "description": "Jump to next for 3rd term" },
-		"select-term-3": { "description": "Jump to next for 4th term" },
-		"select-term-4": { "description": "Jump to next for 5th term" },
-		"select-term-5": { "description": "Jump to next for 6th term" },
-		"select-term-6": { "description": "Jump to next for 7th term" },
-		"select-term-7": { "description": "Jump to next for 8th term" },
-		"select-term-8": { "description": "Jump to next for 9th term" },
-		"select-term-9": { "description": "Jump to next for 10th term" },
-		"select-term-0-reverse": { "description": "Jump to previous for 1st term" },
-		"select-term-1-reverse": { "description": "Jump to previous for 2nd term" },
+		"select-term-0": { "description": "Jump to next (1st keyword)" },
+		"select-term-1": { "description": "Jump to next (2nd keyword)" },
+		"select-term-2": { "description": "Jump to next (3rd keyword)" },
+		"select-term-3": { "description": "Jump to next (4th keyword)" },
+		"select-term-4": { "description": "Jump to next (5th keyword)" },
+		"select-term-5": { "description": "Jump to next (6th keyword)" },
+		"select-term-6": { "description": "Jump to next (7th keyword)" },
+		"select-term-7": { "description": "Jump to next (8th keyword)" },
+		"select-term-8": { "description": "Jump to next (9th keyword)" },
+		"select-term-9": { "description": "Jump to next (10th keyword)" },
+		"select-term-0-reverse": { "description": "Jump to previous (1st keyword)" },
+		"select-term-1-reverse": { "description": "Jump to previous (2nd keyword)" },
 		"select-term-2-reverse": { "description": "Jump to previous for 3rd term" },
 		"select-term-3-reverse": { "description": "Jump to previous for 4th term" },
 		"select-term-4-reverse": { "description": "Jump to previous for 5th term" },

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -95,26 +95,34 @@
 		"focus-term-append": {
 			"description": "Focus input for appending a term"
 		},
+		"step-global": {
+			"suggested_key": { "default": "F2" },
+			"description": "Step to and select next highlight"
+		},
+		"step-global-reverse": {
+			"suggested_key": { "default": "Shift+F2" },
+			"description": "Step to and select previous highlight"
+		},
 		"advance-global": {
 			"suggested_key": { "default": "Alt+Space" },
-			"description": "Jump to next mark in page"
+			"description": "Jump to next highlight block"
 		},
 		"advance-global-reverse": {
 			"suggested_key": { "default": "Alt+Shift+Space" },
-			"description": "Jump to previous mark in page"
+			"description": "Jump to previous highlight block"
 		},
-		"select-term-0": { "description": "Jump to next for 1st term" },
-		"select-term-1": { "description": "Jump to next for 2nd term" },
-		"select-term-2": { "description": "Jump to next for 3rd term" },
-		"select-term-3": { "description": "Jump to next for 4th term" },
-		"select-term-4": { "description": "Jump to next for 5th term" },
-		"select-term-5": { "description": "Jump to next for 6th term" },
-		"select-term-6": { "description": "Jump to next for 7th term" },
-		"select-term-7": { "description": "Jump to next for 8th term" },
-		"select-term-8": { "description": "Jump to next for 9th term" },
-		"select-term-9": { "description": "Jump to next for 10th term" },
-		"select-term-0-reverse": { "description": "Jump to previous for 1st term" },
-		"select-term-1-reverse": { "description": "Jump to previous for 2nd term" },
+		"select-term-0": { "description": "Jump to next (1st keyword)" },
+		"select-term-1": { "description": "Jump to next (2nd keyword)" },
+		"select-term-2": { "description": "Jump to next (3rd keyword)" },
+		"select-term-3": { "description": "Jump to next (4th keyword)" },
+		"select-term-4": { "description": "Jump to next (5th keyword)" },
+		"select-term-5": { "description": "Jump to next (6th keyword)" },
+		"select-term-6": { "description": "Jump to next (7th keyword)" },
+		"select-term-7": { "description": "Jump to next (8th keyword)" },
+		"select-term-8": { "description": "Jump to next (9th keyword)" },
+		"select-term-9": { "description": "Jump to next (10th keyword)" },
+		"select-term-0-reverse": { "description": "Jump to previous (1st keyword)" },
+		"select-term-1-reverse": { "description": "Jump to previous (2nd keyword)" },
 		"select-term-2-reverse": { "description": "Jump to previous for 3rd term" },
 		"select-term-3-reverse": { "description": "Jump to previous for 4th term" },
 		"select-term-4-reverse": { "description": "Jump to previous for 5th term" },

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -96,11 +96,9 @@
 			"description": "Focus input for appending a term"
 		},
 		"step-global": {
-			"suggested_key": { "default": "F2" },
 			"description": "Step to and select next highlight"
 		},
 		"step-global-reverse": {
-			"suggested_key": { "default": "Shift+F2" },
 			"description": "Step to and select previous highlight"
 		},
 		"advance-global": {

--- a/manifest-opera.json
+++ b/manifest-opera.json
@@ -81,28 +81,34 @@
 			"description": "Enable/disable sticky term jumping mode"
 		},
 		"focus-term-append": {
-			"description": "Focus the input for appending a term"
+			"description": "Focus input for appending a term"
+		},
+		"step-global": {
+			"description": "Step to and select next highlight"
+		},
+		"step-global-reverse": {
+			"description": "Step to and select previous highlight"
 		},
 		"advance-global": {
-			"suggested_key": { "default": "Alt+S" },
-			"description": "Jump to next mark in page"
+			"suggested_key": { "default": "Alt+Space" },
+			"description": "Jump to next highlight block"
 		},
 		"advance-global-reverse": {
-			"suggested_key": { "default": "Alt+Shift+S" },
-			"description": "Jump to previous mark in page"
+			"suggested_key": { "default": "Alt+Shift+Space" },
+			"description": "Jump to previous highlight block"
 		},
-		"select-term-0": { "description": "Jump to next for 1st term" },
-		"select-term-1": { "description": "Jump to next for 2nd term" },
-		"select-term-2": { "description": "Jump to next for 3rd term" },
-		"select-term-3": { "description": "Jump to next for 4th term" },
-		"select-term-4": { "description": "Jump to next for 5th term" },
-		"select-term-5": { "description": "Jump to next for 6th term" },
-		"select-term-6": { "description": "Jump to next for 7th term" },
-		"select-term-7": { "description": "Jump to next for 8th term" },
-		"select-term-8": { "description": "Jump to next for 9th term" },
-		"select-term-9": { "description": "Jump to next for 10th term" },
-		"select-term-0-reverse": { "description": "Jump to previous for 1st term" },
-		"select-term-1-reverse": { "description": "Jump to previous for 2nd term" },
+		"select-term-0": { "description": "Jump to next (1st keyword)" },
+		"select-term-1": { "description": "Jump to next (2nd keyword)" },
+		"select-term-2": { "description": "Jump to next (3rd keyword)" },
+		"select-term-3": { "description": "Jump to next (4th keyword)" },
+		"select-term-4": { "description": "Jump to next (5th keyword)" },
+		"select-term-5": { "description": "Jump to next (6th keyword)" },
+		"select-term-6": { "description": "Jump to next (7th keyword)" },
+		"select-term-7": { "description": "Jump to next (8th keyword)" },
+		"select-term-8": { "description": "Jump to next (9th keyword)" },
+		"select-term-9": { "description": "Jump to next (10th keyword)" },
+		"select-term-0-reverse": { "description": "Jump to previous (1st keyword)" },
+		"select-term-1-reverse": { "description": "Jump to previous (2nd keyword)" },
 		"select-term-2-reverse": { "description": "Jump to previous for 3rd term" },
 		"select-term-3-reverse": { "description": "Jump to previous for 4th term" },
 		"select-term-4-reverse": { "description": "Jump to previous for 5th term" },

--- a/src/background.ts
+++ b/src/background.ts
@@ -292,6 +292,8 @@ const updateActionIcon = (enabled?: boolean) =>
 			//browser.commands.update({ name: "toggle-bar", shortcut: "Ctrl+Shift+F" });
 			browser.commands.update({ name: "toggle-research-global", shortcut: "Alt+Shift+J" });
 			browser.commands.update({ name: "focus-term-append", shortcut: "Alt+Period" });
+			browser.commands.update({ name: "step-global", shortcut: "F2" });
+			browser.commands.update({ name: "step-global-reverse", shortcut: "Shift+F2" });
 			for (let i = 0; i < 10; i++) {
 				browser.commands.update({ name: `select-term-${i}`, shortcut: `Alt+Shift+${(i + 1) % 10}` });
 				browser.commands.update({ name: `select-term-${i}-reverse`, shortcut: `Ctrl+Shift+${(i + 1) % 10}` });

--- a/src/shared-content.ts
+++ b/src/shared-content.ts
@@ -264,6 +264,7 @@ enum CommandType {
 	TOGGLE_SELECT,
 	ADVANCE_GLOBAL,
 	SELECT_TERM,
+	STEP_GLOBAL,
 	FOCUS_TERM_INPUT,
 }
 
@@ -340,6 +341,12 @@ const parseCommand = (commandString: string): CommandInfo => {
 			return { type: CommandType.TOGGLE_HIGHLIGHTS };
 		} case "select": {
 			return { type: CommandType.TOGGLE_SELECT };
+		}}
+		break;
+	} case "step": {
+		switch (parts[1]) {
+		case "global": {
+			return { type: CommandType.STEP_GLOBAL, reversed: parts[2] === "reverse" };
 		}}
 		break;
 	} case "advance": {


### PR DESCRIPTION
- Add element stepping method with shortcut [default F2] to focus individual highlights, currently using some duplicate code in preparation for merge with `paint` branch
- Clarify descriptions of jumping shortcuts

Stepping differs from jumping in a number of ways:

- Conjoined highlights are selected from the appropriate end of the current selection (rather than detecting blocks)
- The whole of the region is selected
- Scrolling is never smooth (unless this is the browser's default method)
- There is no indicator other than the selection, although the appropriate marker still pops out
- Focus is removed (if present) but not reassigned