### PR TITLE
Cache storage areas, fix stepping

### DIFF
--- a/src/include/page-build.ts
+++ b/src/include/page-build.ts
@@ -161,7 +161,7 @@ const sendEmail: (
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const sendProblemReport = async (userMessage = "", formFields: Array<FormField>) => {
 	const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-	const session = await getStorageSession([ StorageSession.RESEARCH_INSTANCES ]);
+	const session = await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]);
 	const phrases = session.researchInstances[tab.id as number]
 		? session.researchInstances[tab.id as number].terms.map((term: MatchTerm) => term.phrase).join(" ∣ ")
 		: "";

--- a/src/pages/options.ts
+++ b/src/pages/options.ts
@@ -92,7 +92,7 @@ label[for]:hover
 	 * @param optionsInfo Details of the options to present.
 	 */
 	const loadTab = async (tabIdx: number, tabContainer: HTMLElement, optionsInfo: OptionsInfo) => {
-		const sync = await getStorageSync();
+		const sync = await storageGet("sync");
 		const tabInfo = optionsInfo[tabIdx];
 		const tabButton = document.createElement("button");
 		tabButton.textContent = tabInfo.label;
@@ -136,7 +136,7 @@ label[for]:hover
 						.forEach((preferenceLabel: HTMLElement) => preferenceLabel.classList.remove(OptionClass.MODIFIED));
 				});
 			});
-			setStorageSync(sync);
+			storageSet("sync", sync);
 		});
 		Object.keys(tabInfo.options).forEach(optionKey => {
 			valuesCurrent[optionKey] = {};
@@ -184,7 +184,7 @@ label[for]:hover
 				table.appendChild(row);
 				row.classList.add(OptionClass.PREFERENCE_ROW);
 				row.classList.add(i % 2 ? OptionClass.ODD : OptionClass.EVEN);
-				const valueDefault = defaultOptions[optionKey][preferenceKey];
+				const valueDefault = optionsDefault[optionKey][preferenceKey];
 				const value = sync[optionKey][preferenceKey];
 				if (value === undefined) {
 					preferenceLabel.classList.add(OptionClass.ERRONEOUS);

--- a/src/pages/popup-build.ts
+++ b/src/pages/popup-build.ts
@@ -18,7 +18,7 @@ const loadPopup = (() => {
 							},
 							checkbox: {
 								onLoad: async setChecked => {
-									const local = await getStorageLocal([ StorageLocal.ENABLED ]);
+									const local = await storageGet("local", [ StorageLocal.ENABLED ]);
 									setChecked(local.enabled);
 								},
 								onToggle: checked => {
@@ -35,11 +35,11 @@ const loadPopup = (() => {
 							},
 							checkbox: {
 								onLoad: async setChecked => {
-									const local = await getStorageLocal([ StorageLocal.FOLLOW_LINKS ]);
+									const local = await storageGet("local", [ StorageLocal.FOLLOW_LINKS ]);
 									setChecked(local.followLinks);
 								},
 								onToggle: checked => {
-									setStorageLocal({
+									storageSet("local", {
 										followLinks: checked
 									} as StorageLocalValues);
 								},
@@ -52,11 +52,11 @@ const loadPopup = (() => {
 							},
 							checkbox: {
 								onLoad: async setChecked => {
-									const local = await getStorageLocal([ StorageLocal.PERSIST_RESEARCH_INSTANCES ]);
+									const local = await storageGet("local", [ StorageLocal.PERSIST_RESEARCH_INSTANCES ]);
 									setChecked(local.persistResearchInstances);
 								},
 								onToggle: checked => {
-									setStorageLocal({
+									storageSet("local", {
 										persistResearchInstances: checked
 									} as StorageLocalValues);
 								},
@@ -98,16 +98,16 @@ const loadPopup = (() => {
 									const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 									setChecked(tab.id === undefined ? false :
 										isTabResearchPage(
-											(await getStorageSession([ StorageSession.RESEARCH_INSTANCES ])).researchInstances, tab.id));
+											(await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ])).researchInstances, tab.id));
 								},
 								onToggle: checked => {
 									if (checked) {
-										getStorageSession([ StorageSession.RESEARCH_INSTANCES ]).then(async session => {
+										storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]).then(async session => {
 											const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 											if (tab.id === undefined) {
 												return;
 											}
-											const local = await getStorageLocal([ StorageLocal.PERSIST_RESEARCH_INSTANCES ]);
+											const local = await storageGet("local", [ StorageLocal.PERSIST_RESEARCH_INSTANCES ]);
 											const researchInstance = session.researchInstances[tab.id];
 											if (researchInstance && local.persistResearchInstances) {
 												researchInstance.enabled = true;
@@ -135,14 +135,14 @@ const loadPopup = (() => {
 								onLoad: async setChecked => {
 									const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 									setChecked(tab.id === undefined ? false :
-										!!(await getStorageSession([ StorageSession.RESEARCH_INSTANCES ])).researchInstances[tab.id]);
+										!!(await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ])).researchInstances[tab.id]);
 								},
 								onToggle: async checked => {
 									const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 									if (tab.id === undefined) {
 										return;
 									}
-									const session = await getStorageSession([ StorageSession.RESEARCH_INSTANCES ]);
+									const session = await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]);
 									if (checked) {
 										session.researchInstances[tab.id] = {
 											enabled: false,
@@ -156,7 +156,7 @@ const loadPopup = (() => {
 											disableTabResearch: true,
 										} as BackgroundMessage);
 									}
-									setStorageSession(session);
+									storageSet("session", session);
 								},
 							},
 						},
@@ -234,12 +234,12 @@ const loadPopup = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										getStorageSync([ StorageSync.URL_FILTERS ]).then(sync => //
+										storageGet("sync", [ StorageSync.URL_FILTERS ]).then(sync => //
 											sync.urlFilters.noPageModify.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										getStorageSync([ StorageSync.URL_FILTERS ]).then(sync => {
+										storageGet("sync", [ StorageSync.URL_FILTERS ]).then(sync => {
 											sync.urlFilters.noPageModify = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -247,7 +247,7 @@ const loadPopup = (() => {
 													pathname: value.slice(pathnameStart),
 												};
 											});
-											setStorageSync(sync);
+											storageSet("sync", sync);
 										})
 									,
 								},
@@ -268,12 +268,12 @@ const loadPopup = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										getStorageSync([ StorageSync.URL_FILTERS ]).then(sync => //
+										storageGet("sync", [ StorageSync.URL_FILTERS ]).then(sync => //
 											sync.urlFilters.nonSearch.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										getStorageSync([ StorageSync.URL_FILTERS ]).then(sync => {
+										storageGet("sync", [ StorageSync.URL_FILTERS ]).then(sync => {
 											sync.urlFilters.nonSearch = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -281,7 +281,7 @@ const loadPopup = (() => {
 													pathname: value.slice(pathnameStart),
 												};
 											});
-											setStorageSync(sync);
+											storageSet("sync", sync);
 										})
 									,
 								},
@@ -308,38 +308,38 @@ const loadPopup = (() => {
 							className: "TODOreplace",
 							list: {
 								getLength: () =>
-									getStorageSync([ StorageSync.TERM_LISTS ]).then(sync =>
+									storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync =>
 										sync.termLists.length
 									)
 								,
 								pushWithName: name =>
-									getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+									storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 										sync.termLists.push({
 											name,
 											terms: [],
 											urlFilter: [],
 										});
-										setStorageSync(sync);
+										storageSet("sync", sync);
 									})
 								,
 								removeAt: index =>
-									getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+									storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 										sync.termLists.splice(index, 1);
-										setStorageSync(sync);
+										storageSet("sync", sync);
 									})
 								,
 							},
 							label: {
 								text: "",
 								getText: index =>
-									getStorageSync([ StorageSync.TERM_LISTS ]).then(sync =>
+									storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync =>
 										sync.termLists[index] ? sync.termLists[index].name : ""
 									)
 								,
 								setText: (text, index) =>
-									getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+									storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 										sync.termLists[index].name = text;
-										setStorageSync(sync);
+										storageSet("sync", sync);
 									})
 								,
 								textbox: {
@@ -350,14 +350,14 @@ const loadPopup = (() => {
 								className: "term",
 								list: {
 									getArray: index =>
-										getStorageSync([ StorageSync.TERM_LISTS ]).then(sync =>
+										storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync =>
 											sync.termLists[index].terms as unknown as Array<Record<string, unknown>>
 										)
 									,
 									setArray: (array, index) =>
-										getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+										storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 											sync.termLists[index].terms = array as unknown as typeof sync["termLists"][number]["terms"];
-											setStorageSync(sync);
+											storageSet("sync", sync);
 										})
 									,
 									getNew: text =>
@@ -382,13 +382,13 @@ const loadPopup = (() => {
 													placeholder: "keyword",
 													spellcheck: false,
 													onLoad: async (setText, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setText(sync.termLists[containerIndex].terms[objectIndex] ? sync.termLists[containerIndex].terms[objectIndex].phrase : "");
 													},
 													onChange: (text, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].phrase = text;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -406,13 +406,13 @@ const loadPopup = (() => {
 												},
 												checkbox: {
 													onLoad: async (setChecked, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setChecked(sync.termLists[containerIndex].terms[objectIndex].matchMode.whole);
 													},
 													onToggle: (checked, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].matchMode.whole = checked;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -425,13 +425,13 @@ const loadPopup = (() => {
 												},
 												checkbox: {
 													onLoad: async (setChecked, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setChecked(sync.termLists[containerIndex].terms[objectIndex].matchMode.stem);
 													},
 													onToggle: (checked, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].matchMode.stem = checked;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -444,13 +444,13 @@ const loadPopup = (() => {
 												},
 												checkbox: {
 													onLoad: async (setChecked, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setChecked(sync.termLists[containerIndex].terms[objectIndex].matchMode.case);
 													},
 													onToggle: (checked, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].matchMode.case = checked;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -463,13 +463,13 @@ const loadPopup = (() => {
 												},
 												checkbox: {
 													onLoad: async (setChecked, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setChecked(sync.termLists[containerIndex].terms[objectIndex].matchMode.diacritics);
 													},
 													onToggle: (checked, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].matchMode.diacritics = checked;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -482,13 +482,13 @@ const loadPopup = (() => {
 												},
 												checkbox: {
 													onLoad: async (setChecked, objectIndex, containerIndex) => {
-														const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
+														const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
 														setChecked(sync.termLists[containerIndex].terms[objectIndex].matchMode.regex);
 													},
 													onToggle: (checked, objectIndex, containerIndex) => {
-														getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+														storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 															sync.termLists[containerIndex].terms[objectIndex].matchMode.regex = checked;
-															setStorageSync(sync);
+															storageSet("sync", sync);
 														});
 													},
 												},
@@ -501,12 +501,12 @@ const loadPopup = (() => {
 								className: "TODOreplace",
 								list: {
 									getArray: index =>
-										getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => //
+										storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => //
 											sync.termLists[index].urlFilter.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: (array, index) =>
-										getStorageSync([ StorageSync.TERM_LISTS ]).then(sync => {
+										storageGet("sync", [ StorageSync.TERM_LISTS ]).then(sync => {
 											sync.termLists[index].urlFilter = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -514,7 +514,7 @@ const loadPopup = (() => {
 													pathname: value.slice(pathnameStart),
 												};
 											});
-											setStorageSync(sync);
+											storageSet("sync", sync);
 										})
 									,
 								},
@@ -529,13 +529,13 @@ const loadPopup = (() => {
 										if (tab.id === undefined) {
 											return;
 										}
-										const sync = await getStorageSync([ StorageSync.TERM_LISTS ]);
-										const session = await getStorageSession([ StorageSession.RESEARCH_INSTANCES ]);
+										const sync = await storageGet("sync", [ StorageSync.TERM_LISTS ]);
+										const session = await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]);
 										const researchInstance = session.researchInstances[tab.id];
 										if (researchInstance && (!researchInstance.enabled || !researchInstance.autoOverwritable)) {
 											researchInstance.enabled = true;
 											researchInstance.autoOverwritable = false;
-											await setStorageSession(session);
+											storageSet("session", session);
 										}
 										chrome.runtime.sendMessage({
 											terms: researchInstance


### PR DESCRIPTION
- Make storage setter/getter functions generic
- Use caching to make many getting operations instant, and allow scripts to safely not wait for a setting operation to complete
- Fix interaction of stepping with UI and jumping
- Refactor some naming