### PR TITLE
Fix toolbar and research modification bugs

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1413,8 +1413,11 @@ const insertControls = (() => {
 		bar.addEventListener("focusin", () => {
 			inputsSetFocusable(true);
 		});
-		bar.addEventListener("focusout", () => {
-			inputsSetFocusable(false);
+		bar.addEventListener("focusout", event => {
+			// Only if focus is not moving (and has not already moved) somewhere else within the bar.
+			if (!bar.contains(event.relatedTarget as Node) && !bar.contains(document.activeElement)) {
+				inputsSetFocusable(false);
+			}
 		});
 		window.addEventListener("keydown", event => {
 			if (event.key === "Tab") {

--- a/src/pages/popup-build.ts
+++ b/src/pages/popup-build.ts
@@ -151,13 +151,14 @@ const loadPopup = (() => {
 											highlightsShown: true,
 											terms: [],
 										};
+										await storageSet("session", session);
 									} else {
 										delete session.researchInstances[tab.id];
+										await storageSet("session", session);
 										chrome.runtime.sendMessage({
 											disableTabResearch: true,
 										} as BackgroundMessage);
 									}
-									storageSet("session", session);
 								},
 							},
 						},


### PR DESCRIPTION
- Prevent keyword lists from retaining old terms when reviving a research instance
- Fix deactivating 'keywords stored' from popup
- Allow correctly tabbing from input after opening match-options dialogue (do not immediately return focus to page)