### PR TITLE
Improve match count, enhance *-build pages

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.12.3",
+	"version": "1.13.0",
 
 	"icons": {
 		"16": "/icons/dist/mms-16.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.12.3",
+	"version": "1.13.0",
 
 	"browser_specific_settings": { "gecko": { "id": "mark-my-search@searchmarkers.github.io" } },
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -873,8 +873,9 @@ const getHighlightFlows = (element: Element): Array<HighlightFlow> =>
 const getTermOccurrenceCount = (term: MatchTerm, controlsInfo: ControlsInfo): number => controlsInfo.paintReplaceByClassic
 	? (() => { // Increasingly inaccurate as highlights elements are more often split.
 		const occurrences = Array.from(document.body.getElementsByClassName(getSel(ElementClass.TERM, term.selector)));
-		const matches = occurrences.map(occurrence => occurrence.textContent).join("").match(term.pattern);
-		return matches ? matches.length : 0;
+		//const matches = occurrences.map(occurrence => occurrence.textContent).join("").match(term.pattern);
+		//return matches ? matches.length : 0; // Works poorly in situations such as matching whole words.
+		return occurrences.length; // Poor and changeable heuristic, but so far the most reliable efficient method.
 	})()
 	: getHighlightFlows(document.body)
 		.map(flow => flow.boxesInfo.filter(boxInfo => boxInfo.term.selector === term.selector).length)

--- a/src/include/storage.ts
+++ b/src/include/storage.ts
@@ -13,7 +13,6 @@ type StorageSessionValues = {
 }
 type StorageLocalValues = {
 	[StorageLocal.ENABLED]: boolean
-	[StorageLocal.FOLLOW_LINKS]: boolean
 	[StorageLocal.PERSIST_RESEARCH_INSTANCES]: boolean
 }
 type StorageSyncValues = {
@@ -89,7 +88,6 @@ enum StorageSession { // Keys assumed to be unique across all storage areas (exc
 
 enum StorageLocal {
 	ENABLED = "enabled",
-	FOLLOW_LINKS = "followLinks",
 	PERSIST_RESEARCH_INSTANCES = "persistResearchInstances",
 }
 

--- a/src/pages/popup-build.ts
+++ b/src/pages/popup-build.ts
@@ -54,18 +54,41 @@ const loadPopup = (() => {
 		{
 			className: "panel-general",
 			name: {
-				text: "Options",
+				text: "Controls",
 			},
 			sections: [
 				{
+					interactions: [
+						{
+							className: "action",
+							submitters: [
+								{
+									text: "Get started",
+									onClick: (messageText, formFields, onSuccess) => {
+										chrome.tabs.create({ url: chrome.runtime.getURL("/pages/startpage.html") });
+										onSuccess();
+									},
+								},
+								{
+									text: "Options",
+									onClick: (messageText, formFields, onSuccess) => {
+										chrome.runtime.openOptionsPage();
+										onSuccess();
+									},
+								},
+							],
+						},
+					]
+				},
+				{
 					title: {
-						text: "Settings",
+						text: "Tabs",
 					},
 					interactions: [
 						{
 							className: "option",
 							label: {
-								text: "Highlight web searches",
+								text: "Detect search engines",//"Highlight web searches",
 							},
 							checkbox: {
 								onLoad: async setChecked => {
@@ -82,41 +105,15 @@ const loadPopup = (() => {
 						{
 							className: "option",
 							label: {
-								text: "Follow links",
-							},
-							checkbox: getStorageFieldCheckboxInfo("local", StorageLocal.FOLLOW_LINKS),
-						},
-						{
-							className: "option",
-							label: {
-								text: "Restore keywords in tabs",
+								text: "Restore keywords on reactivation",
 							},
 							checkbox: getStorageFieldCheckboxInfo("local", StorageLocal.PERSIST_RESEARCH_INSTANCES),
-						},
-						{
-							className: "action",
-							submitters: [
-								{
-									text: "Startpage",
-									onClick: (messageText, formFields, onSuccess) => {
-										chrome.tabs.create({ url: chrome.runtime.getURL("/pages/startpage.html") });
-										onSuccess();
-									},
-								},
-								{
-									text: "More options",
-									onClick: (messageText, formFields, onSuccess) => {
-										chrome.runtime.openOptionsPage();
-										onSuccess();
-									},
-								},
-							],
 						},
 					],
 				},
 				{
 					title: {
-						text: "Current Tab Activation",
+						text: "This Tab",
 					},
 					interactions: [
 						{
@@ -160,54 +157,41 @@ const loadPopup = (() => {
 							},
 						},
 						{
-							className: "option",
-							label: {
-								text: "Keywords stored",
-							},
-							checkbox: {
-								onLoad: async setChecked => {
+							className: "action",
+							submitters: [ {
+								text: "Delete keywords",
+								id: "keyword-delete",
+								onLoad: async setEnabled => {
 									const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-									setChecked(tab.id === undefined ? false :
+									setEnabled(tab.id === undefined ? false :
 										!!(await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ])).researchInstances[tab.id]);
 								},
-								onToggle: async checked => {
+								onClick: async () => {
 									const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 									if (tab.id === undefined) {
 										return;
 									}
 									const session = await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]);
-									if (checked) {
-										session.researchInstances[tab.id] = {
-											terms: [],
-											highlightsShown: true,
-											barCollapsed: false,
-											enabled: false,
-										};
-										await storageSet("session", session);
-									} else {
-										delete session.researchInstances[tab.id];
-										await storageSet("session", session);
-										messageSendBackground({
-											disableTabResearch: true,
-										});
-									}
+									delete session.researchInstances[tab.id];
+									await storageSet("session", session);
+									messageSendBackground({
+										disableTabResearch: true,
+									});
 								},
-							},
+							} ],
 						},
 					],
 				},
 				{
 					title: {
-						text: "Contributing",
+						text: "I Have A Problem",
+						expands: true,
 					},
 					interactions: [
 						{
 							className: "action",
-							label: {
-								text: "Report a problem",
-							},
 							submitters: [ {
-								text: "Submit anonymously",
+								text: "Send anonymous feedback",
 								onClick: (messageText, formFields, onSuccess, onError) => {
 									sendProblemReport(messageText, formFields)
 										.then(onSuccess)
@@ -215,7 +199,8 @@ const loadPopup = (() => {
 								},
 								message: {
 									rows: 2,
-									placeholder: "Optional message",
+									placeholder: "Message",
+									required: true,
 								},
 								alerts: {
 									[PageAlertType.SUCCESS]: {
@@ -505,7 +490,7 @@ const loadPopup = (() => {
 	return () => {
 		loadPage(panelsInfo, `
 body
-	{ width: 300px; height: 560px; user-select: none; }
+	{ width: 300px; height: 500px; user-select: none; }
 .container-panel > .panel, .brand
 	{ margin-inline: 0; }
 		`, false);

--- a/src/pages/sendoff-build.ts
+++ b/src/pages/sendoff-build.ts
@@ -21,19 +21,11 @@ const loadSendoff = (() => {
 						{
 							className: "action",
 							label: {
-								text: "We're sorry to see you go. Please consider filling out this form so we can improve for the future!",
-							},
-							note: {
-								text:
-`If you do not wish to submit feedback, simply close this tab and carry on.
-However, Mark My Search will only improve if we know what needs fixing.`,
+								text: "We're sorry to see you go. Please consider submitting this form so we can improve!",
 							},
 						},
 						{
 							className: "action",
-							label: {
-								text: "Information is sent privately with no personal details, and is viewable only by the developer of Mark My Search.",
-							},
 							submitters: [ {
 								text: "Submit",
 								onClick: (messageText, formFields, onSuccess, onError) => {
@@ -59,14 +51,7 @@ However, Mark My Search will only improve if we know what needs fixing.`,
 									{
 										className: "option",
 										label: {
-											text: "Slows down my browser",
-										},
-										checkbox: {},
-									},
-									{
-										className: "option",
-										label: {
-											text: "Too confusing",
+											text: "Breaks or slows down pages",
 										},
 										checkbox: {},
 									},
@@ -80,13 +65,6 @@ However, Mark My Search will only improve if we know what needs fixing.`,
 									{
 										className: "option",
 										label: {
-											text: "Highlighting breaks pages",
-										},
-										checkbox: {},
-									},
-									{
-										className: "option",
-										label: {
 											text: "Highlighting is sometimes incomplete",
 										},
 										checkbox: {},
@@ -94,17 +72,7 @@ However, Mark My Search will only improve if we know what needs fixing.`,
 									{
 										className: "option",
 										label: {
-											text: "Highlighting is ugly or hard to read",
-										},
-										checkbox: {},
-									},
-									{
-										className: "option",
-										label: {
-											text: "Highlighting is overwhelming",
-										},
-										note: {
-											text: "Turn off 'Highlights begin visible' in the options",
+											text: "Highlighting is ugly or overwhelming",
 										},
 										checkbox: {},
 									},
@@ -114,14 +82,14 @@ However, Mark My Search will only improve if we know what needs fixing.`,
 											text: "I don't want all my searches highlighted",
 										},
 										note: {
-											text: "Turn off 'Highlight web searches' in the popup",
+											text: "Turn off \"Detect search engines\" in the popup",
 										},
 										checkbox: {},
 									},
 								],
 								message: {
 									rows: 6,
-									placeholder: "Optional details or support to help us out",
+									placeholder: "Details or support to help us out",
 								},
 								alerts: {
 									[PageAlertType.SUCCESS]: {

--- a/src/pages/startpage-build.ts
+++ b/src/pages/startpage-build.ts
@@ -215,7 +215,7 @@ or assign a shortcut like [Alt+Shift+1] for individual terms.`,
 								text: "Settings - open the popup at any time to quickly change highlighting options.",
 							},
 							note: {
-								text: "Settings - open the popup at any time to quickly change highlighting options.",
+								text: "Click the extensions icon and pin Mark My Search to the toolbar.",
 							},
 						},
 						{


### PR DESCRIPTION
- Revert to less consistent but functionally reliable match count for CLASSIC highlighting (counting highlighting elements); newer method was failing for edge cases like whole-word matching despite being both consistent and acceptably efficient
- Enhance built pages to reduce information density and allow for collapsible sections
- As part of clarifying the popup, remove `followLinks` setting as it could have little realistic use; carrying highlighting into new tabs is now always enabled
- Bump minor version to 13