### PR TITLE
Improve term-replacing consistency

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.13.0",
+	"version": "1.13.1",
 
 	"icons": {
 		"16": "/icons/dist/mms-16.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.13.0",
+	"version": "1.13.1",
 
 	"browser_specific_settings": { "gecko": { "id": "mark-my-search@searchmarkers.github.io" } },
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -405,7 +405,6 @@ const updateActionIcon = (enabled?: boolean) =>
 			researchInstance.enabled = true;
 			highlightActivation = activateHighlightingInTab(tabId, {
 				terms: researchInstance.terms,
-				termsOnHold: searchDetails.isSearch ? undefined : [],
 				toggleHighlightsOn: determineToggleHighlightsOn(researchInstance.highlightsShown, overrideHighlightsShown),
 				toggleBarCollapsedOn: researchInstance.barCollapsed,
 				barControlsShown: sync.barControlsShown,

--- a/src/pages/startpage-build.ts
+++ b/src/pages/startpage-build.ts
@@ -74,7 +74,7 @@ const loadStartpage = (() => {
 						{
 							className: "action",
 							label: {
-								text: "Activate or deactivate with Alt+Shift+M",
+								text: "Activate or deactivate with Alt+M",
 							},
 						},
 						{


### PR DESCRIPTION
- Make 'held' keywords more commonly the same as those in the current search
- Update Alt+Shift+M shortcut to Alt+M in docs