### PR TITLE
Remove page-freeze error, enhance UI input

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.13.6",
+	"version": "1.13.7",
 
 	"icons": {
 		"16": "/icons/dist/mms-16.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.13.6",
+	"version": "1.13.7",
 
 	"browser_specific_settings": { "gecko": { "id": "mark-my-search@searchmarkers.github.io" } },
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -767,6 +767,7 @@ const insertTermInput = (() => {
 			entries.forEach(entry => entry.contentRect.width === 0 ? hide() : undefined)
 		)).observe(input);
 		input.addEventListener("keydown", event => {
+			event.stopPropagation();
 			switch (event.key) {
 			case "Enter": {
 				if (event.shiftKey) {
@@ -970,8 +971,8 @@ const refreshTermControl = (term: MatchTerm, idx: number, highlightTags: Highlig
 	control.classList.add(getSel(ElementClass.TERM, term.selector));
 	updateTermControlMatchModeClassList(term.matchMode, control.classList);
 	const controlContent = control.getElementsByClassName(getSel(ElementClass.CONTROL_CONTENT))[0] as HTMLElement;
-	controlContent.onclick = () => // Overrides previous event handler in case of new term.
-		focusOnTermJump(controlsInfo, highlightTags, false, term);
+	controlContent.onclick = event => // Overrides previous event handler in case of new term.
+		focusOnTermJump(controlsInfo, highlightTags, event.shiftKey, term);
 	controlContent.textContent = term.phrase;
 	// TODO make function
 	Array.from(control.getElementsByClassName(getSel(ElementClass.OPTION))).forEach(option =>
@@ -2124,6 +2125,7 @@ const generateTermHighlightsUnderNode = (() => {
 		highlight.textContent = text.substring(start, end);
 		textEndNode.textContent = text.substring(end);
 		(textEndNode.parentNode as Node).insertBefore(highlight, textEndNode);
+		(highlight.parentNode as Node)["markmysearchKnown"] = true;
 		nodeItems.insertAfter(nodeItemPrevious, highlight.firstChild as Text);
 		if (textStart !== "") {
 			const textStartNode = document.createTextNode(textStart);
@@ -2132,7 +2134,6 @@ const generateTermHighlightsUnderNode = (() => {
 			return ((nodeItemPrevious ? nodeItemPrevious.next : nodeItems.first) as UnbrokenNodeListItem)
 				.next as UnbrokenNodeListItem;
 		}
-		(highlight.parentNode as Node)["markmysearchKnown"] = true;
 		return (nodeItemPrevious ? nodeItemPrevious.next : nodeItems.first) as UnbrokenNodeListItem;
 	};
 
@@ -2641,10 +2642,10 @@ const mutationUpdatesGet = (() => {
 						}
 					}
 				}
-				for (const element of elementsKnown) {
-					delete element["markmysearchKnown"];
-				}
 				if (elementsKnown.size) {
+					for (const element of elementsKnown) {
+						delete element["markmysearchKnown"];
+					}
 					mutationUpdates.observe();
 					return;
 				}


### PR DESCRIPTION
Related to #119 

- Correctly always label the parent node of a newly highlighted element as 'known', rather than only sometimes (preventing an infinite feedback loop which could freeze pages)
- Implement shift+click keyword for scrolling to previous match
- Try to prevent page from detecting keypresses in keyword inputs