### PR TITLE
Optimise term count checks, greatly optimise PAINT

### DIFF
--- a/src/pages/options.ts
+++ b/src/pages/options.ts
@@ -306,7 +306,7 @@ PAINT
 							,
 							type: PreferenceType.BOOLEAN,
 						},
-						paintUseExperimental: {
+						/*paintUseExperimental: {
 							label: "Use experimental browser APIs (hover for details)",
 							tooltip:
 `Mark My Search can highlight using experimental APIs. The behavior of this flag will change over time.
@@ -320,7 +320,7 @@ PAINT
 • Chromium: The CSS [Houdini] Painting API is used instead of SVG rendering.`
 							,
 							type: PreferenceType.BOOLEAN,
-						},
+						},*/
 						hues: {
 							label: "Highlight color hue cycle",
 							type: PreferenceType.ARRAY_NUMBER,


### PR DESCRIPTION
- Always use experimental PAINT APIs
- Optimise getting term occurrence counts for PAINT
  - Only check for first term occurrence in PAINT when updating term status
  - Only update term tooltips on mouseover
- Optimise mutation observation and updating for PAINT (try to only perform updates once even when multiple mutations happened to the same elements)
- Correctly calculate scroll markers for PAINT even if some elements were not "highlightable" (i.e. anchors and their descendants in Chromium for Paint Worklets)

Fixes #124 