### PR TITLE
Do not remove old controls for now

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -3168,7 +3168,8 @@ const getTermsFromSelection = () => {
 		if (!paintUsePaintingFallback) {
 			(CSS["paintWorklet"] as PaintWorkletType).addModule(chrome.runtime.getURL("/dist/paint.js"));
 		}
-		controlsRemove();
+		// Can't remove controls because a script may be left behind from the last install, and start producing unhandled errors. FIXME
+		//controlsRemove();
 		const commands: BrowserCommands = [];
 		const terms: MatchTerms = [];
 		const hues: TermHues = [];


### PR DESCRIPTION
- Remove `controlsRemove()` line with note
  - A script sometimes remains in a seemingly half active state, needs investigation