### PR TITLE
Enhance bar tabbing, retain _ on hi'ing selection

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.14.0",
+	"version": "1.14.1",
 
 	"icons": {
 		"16": "/icons/dist/mms-16.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.14.0",
+	"version": "1.14.1",
 
 	"browser_specific_settings": { "gecko": { "id": "mark-my-search@searchmarkers.github.io" } },
 


### PR DESCRIPTION
Enhance bar tabbing, retain _ on hi'ing selection
    
- Correctly allow Tabs to propagate to the bar level only, so they can
  be handled there
- Add a special case for tabbing from the last term input in case the
  term-append button is hidden (so needs focusing manually)
- Do not remove connector punctuation (Pc) when getting terms from
  selection (https://en.wikipedia.org/wiki/Unicode_character_property)

Fixes #129