### PR TITLE
Always repair (sync) options on init

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.14.1",
+	"version": "1.14.2",
 
 	"icons": {
 		"16": "/icons/dist/mms-16.png",

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Mark My Search",
 	"description": "Highlight searched keywords. Find matches instantly.",
-	"version": "1.14.1",
+	"version": "1.14.2",
 
 	"browser_specific_settings": { "gecko": { "id": "mark-my-search@searchmarkers.github.io" } },
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -288,6 +288,7 @@ const updateActionIcon = (enabled?: boolean) =>
 			console.warn("TODO fix bookmark search engines check", error);
 		}
 		createContextMenuItems();
+		optionsRepair();
 		storageInitialize();
 		updateActionIcon();
 	};
@@ -298,7 +299,6 @@ const updateActionIcon = (enabled?: boolean) =>
 				chrome.tabs.create({ url: chrome.runtime.getURL("/pages/startpage.html") });
 			}
 		}
-		optionsRepair();
 		initialize();
 	};
 


### PR DESCRIPTION
- Reduce likelihood of options being broken and not getting repaired until reinstalled
- Bump (patch) version to 1.14.2