### PR TITLE
Improve match-mode selection, refactor

### DIFF
--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -58,6 +58,7 @@
 		{
 			"resources": [
 				"/dist/paint.js",
+				"/icons/mms.svg",
 				"/icons/arrow.svg",
 				"/icons/close.svg",
 				"/icons/search.svg",

--- a/manifest/chromium.json
+++ b/manifest/chromium.json
@@ -42,7 +42,7 @@
 
 	"options_ui": {
 		"page": "/pages/options.html",
-		"browser_style": true
+		"browser_style": false
 	},
 
 	"action": {

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -53,7 +53,7 @@
 
 	"options_ui": {
 		"page": "/pages/options.html",
-		"browser_style": true
+		"browser_style": false
 	},
 
 	"action": {

--- a/manifest/firefox.json
+++ b/manifest/firefox.json
@@ -66,6 +66,7 @@
 		{
 			"resources": [
 				"/dist/paint.js",
+				"/icons/mms.svg",
 				"/icons/arrow.svg",
 				"/icons/close.svg",
 				"/icons/search.svg",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
 	"displayName": "Mark My Search",
 	"scripts": {
 		"icons-convert": "bash -c 'mkdir -p icons/dist; SIZES=(16 32 48 64 96 128 240 300); for SIZE in ${SIZES[@]}; do inkscape icons/mms.svg -w $SIZE -h $SIZE -o icons/dist/mms-${SIZE}.png; done; SIZES=(32); for SIZE in ${SIZES[@]}; do inkscape icons/mms-off.svg -w $SIZE -h $SIZE -o icons/dist/mms-off-${SIZE}.png; done'",
-		"scripts-build": "tsc -p tsconfig.json",
+		"scripts-build": "rm --recursive dist; tsc --project tsconfig.json",
 		"prepare-firefox": "ln --force --symbolic manifest/firefox.json manifest.json",
 		"prepare-chromium": "ln --force --symbolic manifest/chromium.json manifest.json",
-		"pack-firefox": "npm run prepare-firefox; mkdir --parents pack; rm --force pack/mark_my_search-firefox.zip; zip pack/mark_my_search-firefox.zip * -ri dist/**\\* icons/**\\* pages/**\\* lib/**\\* manifest.json",
-		"pack-chromium": "npm run prepare-chromium; mkdir --parents pack; rm --force pack/mark_my_search-chromium.zip; zip pack/mark_my_search-chromium.zip * -ri dist/**\\* icons/**\\* pages/**\\* lib/**\\* manifest.json"
+		"pack-firefox": "rm --force pack/mark_my_search-firefox.zip; npm run scripts-build; npm run prepare-firefox; mkdir --parents pack; zip pack/mark_my_search-firefox.zip * -ri dist/**\\* icons/**\\* pages/**\\* lib/**\\* manifest.json",
+		"pack-chromium": "rm --force pack/mark_my_search-chromium.zip; npm run scripts-build; npm run prepare-chromium; mkdir --parents pack; zip pack/mark_my_search-chromium.zip * -ri dist/**\\* icons/**\\* pages/**\\* lib/**\\* manifest.json"
 	},
 	"repository": {
 		"type": "git",

--- a/src/content.ts
+++ b/src/content.ts
@@ -1933,9 +1933,9 @@ const constructHighlightStyleRule: (highlightId: string, boxes: Array<HighlightB
 paintUseExperimental
 	? paintUsePaintingFallback
 		? highlightId =>
-			`body [markmysearch-h_id="${highlightId}"] { background: -moz-element(#${
+			`body [markmysearch-h_id="${highlightId}"] { background-image: -moz-element(#${
 				getSel(ElementID.DRAW_ELEMENT, highlightId)
-			}) no-repeat !important; }`
+			}) !important; background-repeat: no-repeat !important; }`
 		: (highlightId, boxes) =>
 			`body [markmysearch-h_id="${highlightId}"] { --markmysearch-boxes: ${
 				JSON.stringify(boxes)

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,11 +6,12 @@ type HighlightTags = {
 type TermHues = Array<number>
 type ControlButtonName = keyof StorageSyncValues[StorageSync.BAR_CONTROLS_SHOWN]
 type ControlButtonInfo = {
-	controlClasses?: Array<ElementClass>
-	buttonClass?: ElementClass
+	controlClasses?: Array<EleClass>
+	buttonClasses?: Array<EleClass>
 	path?: string
+	pathSecondary?: string
 	label?: string
-	containerId: ElementID
+	containerId: EleID
 	onClick?: () => void
 	setUp?: (container: HTMLElement) => void
 }
@@ -28,58 +29,66 @@ type MutationUpdates = { observe: () => void, disconnect: () => void }
 type StyleUpdates = { observe: (element: Element) => void, disconnectAll: () => void }
 
 enum AtRuleID {
-	FLASH = "flash",
-	MARKER_ON = "marker-on",
-	MARKER_OFF = "marker-off",
+	FLASH = "markmysearch__flash",
+	MARKER_ON = "markmysearch__marker_on",
+	MARKER_OFF = "markmysearch__marker_off",
 }
 
-enum ElementProperty {
-	INFO = "markmysearchCache",
+enum EleProperty {
+	INFO = "markmysearch__cache",
 }
 
-enum ElementClass {
-	HIGHLIGHTS_SHOWN = "highlights-shown",
-	BAR_HIDDEN = "bar-hidden",
-	CONTROL = "control",
-	CONTROL_PAD = "control-pad",
-	CONTROL_CONTENT = "control-content",
-	CONTROL_BUTTON = "control-button",
-	CONTROL_REVEAL = "control-reveal",
-	CONTROL_EDIT = "control-edit",
-	OPTION_LIST = "options",
-	OPTION = "option",
-	TERM = "term",
-	FOCUS = "focus",
-	FOCUS_CONTAINER = "focus-contain",
-	FOCUS_REVERT = "focus-revert",
-	REMOVE = "remove",
-	DISABLED = "disabled",
-	COLLAPSED = "collapsed",
-	UNCOLLAPSIBLE = "collapsed-impossible",
-	MATCH_REGEX = "match-regex",
-	MATCH_CASE = "match-case",
-	MATCH_STEM = "match-stem",
-	MATCH_WHOLE = "match-whole",
-	MATCH_DIACRITICS = "match-diacritics",
-	PRIMARY = "primary",
-	SECONDARY = "secondary",
-	OVERRIDE_VISIBILITY = "override-visibility",
-	OVERRIDE_FOCUS = "override-focus",
-	BAR_CONTROLS = "bar-controls",
+enum EleClass {
+	HIGHLIGHTS_SHOWN = "mms__highlights_shown",
+	BAR_HIDDEN = "mms__bar_hidden",
+	CONTROL = "mms__control",
+	CONTROL_PAD = "mms__control_pad",
+	CONTROL_INPUT = "mms__control_input",
+	CONTROL_CONTENT = "mms__control_content",
+	CONTROL_BUTTON = "mms__control_button",
+	CONTROL_REVEAL = "mms__control_reveal",
+	CONTROL_EDIT = "mms__control_edit",
+	OPTION_LIST = "mms__options",
+	OPTION = "mms__option",
+	TERM = "mms__term",
+	FOCUS = "mms__focus",
+	FOCUS_CONTAINER = "mms__focus_contain",
+	FOCUS_REVERT = "mms__focus_revert",
+	REMOVE = "mms__remove",
+	DISABLED = "mms__disabled",
+	WAS_FOCUSED = "mms__was_focused",
+	MENU_OPEN = "mms__menu_open",
+	MENU_JUST_CLOSED_BY_BUTTON = "mms__menu_just_closed",
+	OPENED_MENU = "mms__opened_menu",
+	COLLAPSED = "mms__collapsed",
+	UNCOLLAPSIBLE = "mms__collapsed_impossible",
+	MATCH_REGEX = "mms__match_regex",
+	MATCH_CASE = "mms__match_case",
+	MATCH_STEM = "mms__match_stem",
+	MATCH_WHOLE = "mms__match_whole",
+	MATCH_DIACRITICS = "mms__match_diacritics",
+	PRIMARY = "mms__primary",
+	SECONDARY = "mms__secondary",
+	BAR_CONTROLS = "mms__bar_controls",
 }
 
-enum ElementID {
-	STYLE = "style",
-	STYLE_PAINT = "style-paint",
-	BAR = "bar",
-	BAR_LEFT = "bar-left",
-	BAR_TERMS = "bar-terms",
-	BAR_RIGHT = "bar-right",
-	MARKER_GUTTER = "markers",
-	DRAW_CONTAINER = "draw-container",
-	DRAW_ELEMENT = "draw",
-	INPUT = "input",
+enum EleID {
+	STYLE = "markmysearch__style",
+	STYLE_PAINT = "markmysearch__style_paint",
+	BAR = "markmysearch__bar",
+	BAR_LEFT = "markmysearch__bar_left",
+	BAR_TERMS = "markmysearch__bar_terms",
+	BAR_RIGHT = "markmysearch__bar_right",
+	MARKER_GUTTER = "markmysearch__markers",
+	DRAW_CONTAINER = "markmysearch__draw_container",
+	DRAW_ELEMENT = "markmysearch__draw",
+	INPUT = "markmysearch__input",
 }
+
+const ELEMENT_IS_KNOWN = "markmysearch__known";
+
+const HIGHLIGHT_TAG = "mms-h";
+const HIGHLIGHT_TAG_UPPER = "MMS-H";
 
 enum TermChange {
 	REMOVE = -1,
@@ -113,7 +122,7 @@ interface HighlightBoxInfo {
 }
 
 interface HighlightBox {
-	selector: string
+	token: string
 	x: number
 	y: number
 	width: number
@@ -192,16 +201,17 @@ const termsSet = async (terms: MatchTerms) => {
 	await messageSendBackground({ terms });
 };
 
-/**
- * Gets a selector for selecting by ID or class, or for CSS at-rules. Abbreviated due to prolific use.
- * __Always__ use for ID, class, and at-rule identifiers.
- * @param identifier The extension-level unique ID, class, or at-rule identifier.
- * @param argument An optional secondary component to the identifier.
- * @returns The selector string, being a constant selector prefix and both components joined by hyphens.
- */
-const getSel = (identifier: ElementID | ElementClass | AtRuleID, argument?: string | number): string =>
-	argument === undefined ? `markmysearch-${identifier}` : `markmysearch-${identifier}-${argument}`
-;
+const getTermClass = (termToken: string): string => EleClass.TERM + "-" + termToken;
+
+const getTermToken = (termClass: string) => termClass.slice(EleClass.TERM.length + 1);
+
+const getControlPadClass = (index: number) => EleClass.CONTROL_PAD + "-" + index.toString();
+
+const getMatchModeOptionClass = (matchType: keyof MatchMode) => EleClass.OPTION + "-" + matchType;
+
+const getInputIdSequential = () => EleID.INPUT + "-" + getIdSequential.next().value.toString();
+
+const getElementDrawId = (highlightId: string) => EleID.DRAW_ELEMENT + "-" + highlightId;
 
 /**
  * Fills a CSS stylesheet element to style all UI elements we insert.
@@ -209,214 +219,386 @@ const getSel = (identifier: ElementID | ElementClass | AtRuleID, argument?: stri
  * @param hues Color hues for term styles to cycle through.
  */
 const fillStylesheetContent = (terms: MatchTerms, hues: TermHues, controlsInfo: ControlsInfo) => {
-	const style = document.getElementById(getSel(ElementID.STYLE)) as HTMLStyleElement;
+	const style = document.getElementById(EleID.STYLE) as HTMLStyleElement;
 	const zIndexMin = -(2**31);
 	const zIndexMax = 2**31 - 1;
 	const makeImportant = (styleText: string): string =>
 		styleText.replace(/;/g, " !important;"); // Prevent websites from overriding rules with !important;
 	style.textContent = makeImportant(`
 /* || Term Buttons and Input */
-#${getSel(ElementID.BAR)} ::selection
-	{ background: Highlight; color: HighlightText; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)} input,
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.BAR_CONTROLS)} .${getSel(ElementClass.CONTROL)} input
-	{ width: 5em; padding: 0 2px 0 2px; margin-left: 4px; border: none; outline: revert;
-	box-sizing: unset; font-family: revert; white-space: pre; color: hsl(0 0% 0%); }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)} button:disabled,
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)} button:disabled *,
-#${getSel(ElementID.BAR)}:not(:hover) .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_FOCUS)}),
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_VISIBILITY)}),
-#${getSel(ElementID.BAR)}:not(:hover) .${getSel(ElementClass.BAR_CONTROLS)} .${getSel(ElementClass.CONTROL)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_FOCUS)}),
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.BAR_CONTROLS)} .${getSel(ElementClass.CONTROL)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_VISIBILITY)})
-	{ width: 0; padding: 0; margin: 0; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_REVEAL)} img
-	{ width: 0.5em; }
-#${getSel(ElementID.BAR)}
-.${getSel(ElementClass.CONTROL_PAD)} .${getSel(ElementClass.CONTROL_EDIT)} .${getSel(ElementClass.PRIMARY)}
-	{ display: none; }
-#${getSel(ElementID.BAR)}:not(:hover) .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_FOCUS)})
-+ .${getSel(ElementClass.CONTROL_EDIT)} .${getSel(ElementClass.PRIMARY)},
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_VISIBILITY)})
-+ .${getSel(ElementClass.CONTROL_EDIT)} .${getSel(ElementClass.PRIMARY)}
-	{ display: block; }
-#${getSel(ElementID.BAR)}:not(:hover) .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_FOCUS)})
-+ .${getSel(ElementClass.CONTROL_EDIT)} .${getSel(ElementClass.SECONDARY)},
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)}
-input:not(:focus, .${getSel(ElementClass.OVERRIDE_VISIBILITY)})
-+ .${getSel(ElementClass.CONTROL_EDIT)} .${getSel(ElementClass.SECONDARY)}
-	{ display: none; }
+
+#${EleID.BAR} {
+	& ::selection {
+		background: Highlight;
+		color: HighlightText;
+	}
+	& .${EleClass.CONTROL_PAD} .${EleClass.CONTROL_EDIT} {
+		.${EleClass.PRIMARY} {
+			display: block;
+		}
+		.${EleClass.SECONDARY} {
+			display: none;
+		}
+	}
+	& .${EleClass.CONTROL_PAD} button:disabled,
+	& .${EleClass.CONTROL_PAD} button:disabled *,
+	& .${EleClass.CONTROL_INPUT} {
+		width: 0;
+		padding: 0;
+		margin: 0;
+	}
+	& .${EleClass.CONTROL_INPUT} {
+		border: none;
+		outline: revert;
+		box-sizing: unset;
+		font-family: revert;
+		white-space: pre;
+		color: hsl(0 0% 0%);
+	}
+	&:active .${EleClass.CONTROL_INPUT}.${EleClass.WAS_FOCUSED},
+	& .${EleClass.CONTROL_INPUT}:is(:focus, .${EleClass.OPENED_MENU}) {
+		width: 5em;
+		padding: 0 2px 0 2px;
+		margin-inline: 3px;
+		& + .${EleClass.CONTROL_EDIT} {
+			& .${EleClass.PRIMARY} {
+				display: none;
+			}
+			& .${EleClass.SECONDARY} {
+				display: block;
+			}
+		}
+	}
+	&.${EleClass.COLLAPSED} .${controlGetClass("toggleBarCollapsed")} .${EleClass.PRIMARY},
+	&:not(.${EleClass.COLLAPSED}) .${controlGetClass("toggleBarCollapsed")} .${EleClass.SECONDARY} {
+		display: none;
+	}
+	& .${EleClass.CONTROL_REVEAL} img {
+		width: 0.5em;
+	}
+}
+
 /**/
 
 /* || Term Matching Option Hints */
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.MATCH_REGEX)} .${getSel(ElementClass.CONTROL_CONTENT)}
-	{ font-weight: bold; }
-#${getSel(ElementID.BAR_RIGHT)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_REGEX)}
-.${getSel(ElementClass.CONTROL_CONTENT)}::before
-	{ content: "(.*)"; margin-right: 2px; font-weight: bold; }
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_CASE)}
-.${getSel(ElementClass.CONTROL_CONTENT)},
-#${getSel(ElementID.BAR_RIGHT)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_CASE)}
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ padding-top: 0; border-top: 1px dashed black; }
-#${getSel(ElementID.BAR_TERMS)}
-.${getSel(ElementClass.CONTROL)}:not(.${getSel(ElementClass.MATCH_STEM)}, .${getSel(ElementClass.MATCH_REGEX)})
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ text-decoration: underline; text-decoration-skip-ink: none; }
-#${getSel(ElementID.BAR_RIGHT)}
-.${getSel(ElementClass.CONTROL)}:not(.${getSel(ElementClass.MATCH_STEM)})
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ border-bottom: 3px solid hsl(0 0% 38%); }
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_WHOLE)}
-.${getSel(ElementClass.CONTROL_CONTENT)},
-#${getSel(ElementID.BAR_RIGHT)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_WHOLE)}
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ padding-inline: 2px; border-inline: 2px solid hsl(0 0% 0% / 0.4); }
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_DIACRITICS)}
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ font-style: italic; }
-#${getSel(ElementID.BAR_RIGHT)} .${getSel(ElementClass.CONTROL)}.${getSel(ElementClass.MATCH_DIACRITICS)}
-.${getSel(ElementClass.CONTROL_CONTENT)}
-	{ border-left: 3px dashed black; }
+
+#${EleID.BAR_TERMS} {
+	& .${EleClass.CONTROL} {
+		&.${EleClass.MATCH_REGEX} .${EleClass.CONTROL_CONTENT} {
+			font-weight: bold;
+		}
+		&.${EleClass.MATCH_DIACRITICS} .${EleClass.CONTROL_CONTENT} {
+			font-style: italic;
+		}
+	}
+}
+
+#${EleID.BAR_TERMS},
+#${EleID.BAR_RIGHT} {
+	& .${EleClass.CONTROL} {
+		&.${EleClass.MATCH_CASE} .${EleClass.CONTROL_CONTENT} {
+			padding-top: 0;
+			border-top: 2px dashed black;
+		}
+		&.${EleClass.MATCH_WHOLE} .${EleClass.CONTROL_CONTENT} {
+			padding-inline: 2px;
+			border-inline: 2px solid hsl(0 0% 0% / 0.4);
+		}
+	}
+}
+
+#${EleID.BAR_RIGHT} {
+	& .${EleClass.CONTROL} {
+		&.${EleClass.MATCH_REGEX} .${EleClass.CONTROL_CONTENT}::before {
+			content: "(.*)";
+			margin-right: 2px;
+			font-weight: bold;
+		}
+		&:not(.${EleClass.MATCH_STEM}) .${EleClass.CONTROL_CONTENT} {
+			border-bottom: 3px solid hsl(0 0% 38%);
+		}
+		&.${EleClass.MATCH_DIACRITICS} .${EleClass.CONTROL_CONTENT} {
+			border-left: 3px dashed black;
+		}
+	}
+}
+
+#${EleID.BAR_TERMS} .${EleClass.CONTROL}:not(.${EleClass.MATCH_STEM},
+.${EleClass.MATCH_REGEX}) .${EleClass.CONTROL_CONTENT} {
+	text-decoration: underline;
+	text-decoration-skip-ink: none;
+}
+
 /**/
 
 /* || Bar */
-#${getSel(ElementID.BAR)}
-	{ all: revert; position: fixed; top: 0; left: 0; z-index: ${zIndexMax};
-	color-scheme: light; font-size: ${controlsInfo.barLook.fontSize}; line-height: initial; user-select: none; pointer-events: none; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.BAR_HIDDEN)}
-	{ display: none; }
-#${getSel(ElementID.BAR)} *
-	{ all: revert; font: revert; font-family: sans-serif; font-size: inherit; line-height: 120%; padding: 0; }
-#${getSel(ElementID.BAR)} :not(input)
-	{ outline: none; }
-#${getSel(ElementID.BAR)} img
-	{ height: 1.1em; width: 1.1em; object-fit: cover; }
-#${getSel(ElementID.BAR)} button
-	{ display: flex; align-items: center; padding-inline: 4px; margin-block: 0; border: none; border-radius: inherit;
-	background: none; color: hsl(0 0% 0%); cursor: pointer; letter-spacing: normal; transition: unset; }
-#${getSel(ElementID.BAR)} > *
-	{ display: inline; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL)}
-	{ display: inline-block; vertical-align: top; margin-left: 0.5em; pointer-events: auto; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.COLLAPSED)} > * > *:not(.${getSel(ElementClass.UNCOLLAPSIBLE)})
-	{ display: none; }
+
+#${EleID.BAR} {
+	& {
+		all: revert;
+		position: fixed;
+		top: 0;
+		left: 0;
+		z-index: ${zIndexMax};
+		color-scheme: light;
+		font-size: ${controlsInfo.barLook.fontSize};
+		line-height: initial;
+		user-select: none;
+		pointer-events: none;
+	}
+	&.${EleClass.BAR_HIDDEN} {
+		display: none;
+	}
+	& * {
+		all: revert;
+		font: revert;
+		font-family: sans-serif;
+		font-size: inherit;
+		line-height: 120%;
+		padding: 0;
+	}
+	& :not(input) {
+		outline: none;
+	}
+	& img {
+		height: 1.1em;
+		width: 1.1em;
+		object-fit: cover;
+	}
+	& button {
+		display: flex;
+		align-items: center;
+		padding-inline: 4px;
+		margin-block: 0;
+		border: none;
+		border-radius: inherit;
+		background: none;
+		color: hsl(0 0% 0%);
+		cursor: pointer;
+		letter-spacing: normal;
+		transition: unset;
+	}
+	& > * {
+		display: inline;
+	}
+	& .${EleClass.CONTROL} {
+		display: inline-block;
+		vertical-align: top;
+		margin-left: 0.5em;
+		pointer-events: auto;
+	}
+	&.${EleClass.COLLAPSED} > * > *:not(.${EleClass.UNCOLLAPSIBLE}) {
+		display: none;
+	}
+}
+
 /**/
 
 /* || Term Pulldown */
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION_LIST)}:is(:focus-within, :active),
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION_LIST)}.${getSel(ElementClass.OVERRIDE_VISIBILITY)},
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)}:active:not(:hover)
-+ .${getSel(ElementClass.OPTION_LIST)}
-	{ display: flex; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION_LIST)}:focus-within .${getSel(ElementClass.OPTION)}::first-letter
-	{ text-decoration: underline; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION_LIST)}
-	{ display: none; position: absolute; flex-direction: column; padding: 0; width: max-content; margin: 0 0 0 4px;
-	z-index: 1; font-size: max(14px, 0.8em); }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION)}
-	{ display: flex; padding-block: 2px; background: hsl(0 0% 94% / 0.76);
-	color: hsl(0 0% 6%); filter: grayscale(100%); width: 100%; text-align: left;
-	border-width: 2px; border-color: hsl(0 0% 40% / 0.7); border-left-style: solid; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.OPTION)}:hover
-	{ background: hsl(0 0% 100%); }
+
+#${EleID.BAR} {
+	& .${EleClass.CONTROL}:active .${EleClass.CONTROL_PAD}:not(:hover) ~ .${EleClass.OPTION_LIST},
+	& .${EleClass.MENU_OPEN} .${EleClass.OPTION_LIST} {
+		display: flex;
+	}
+	& .${EleClass.OPTION_LIST}:focus-within .${EleClass.OPTION}::first-letter {
+		text-decoration: underline;
+	}
+	& .${EleClass.OPTION_LIST} {
+		display: none;
+		position: absolute;
+		flex-direction: column;
+		padding: 0;
+		width: max-content;
+		margin: 0 0 0 4px;
+		z-index: 1;
+		font-size: max(14px, 0.84em) /* Make the font size a proportion of the overall font size, down to 14px */;
+	}
+	& .${EleClass.OPTION} {
+		& {
+			display: flex;
+			padding-block: 3px;
+			background: hsl(0 0% 94% / 0.76);
+			color: hsl(0 0% 6%);
+			width: 100%;
+			text-align: left;
+			border-width: 2px;
+			border-color: hsl(0 0% 40% / 0.7);
+			border-left-style: solid;
+		}
+		& input[type='checkbox'] {
+			margin-block: 0;
+			margin-inline: 4px;
+			width: 1em;
+		}
+		&:hover {
+			background: hsl(0 0% 100%);
+		}
+	}
+}
+
 /**/
 
 /* || Bar Controls */
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.CONTROL)}
-	{ white-space: pre; }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)}
-	{ display: flex; height: 1.3em; background: hsl(0 0% 90% / ${controlsInfo.barLook.opacityControl}); color: hsl(0 0% 0%);
-	border-style: none; border-radius: ${controlsInfo.barLook.borderRadius}; box-shadow: 1px 1px 5px; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.DISABLED)} .${getSel(ElementClass.CONTROL_PAD)}
-	{ background: hsl(0 0% 90% / min(${controlsInfo.barLook.opacityControl}, 0.4)); }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)} button:hover
-	{ background: hsl(0 0% 65%); }
-#${getSel(ElementID.BAR)} .${getSel(ElementClass.CONTROL_PAD)} button:active
-	{ background: hsl(0 0% 50%); }
-#${getSel(ElementID.BAR)} > :not(#${getSel(ElementID.BAR_TERMS)})
-> .${getSel(ElementClass.DISABLED)}:not(:focus-within, .${getSel(ElementClass.OVERRIDE_VISIBILITY)})
-	{ display: none; }
-#${getSel(ElementID.BAR)}:not(.${getSel(ElementClass.DISABLED)}) #${getSel(ElementID.BAR_TERMS)}
-.${getSel(ElementClass.CONTROL_PAD)}.${getSel(ElementClass.DISABLED)}
-	{ display: flex; background: hsl(0 0% 80% / min(${controlsInfo.barLook.opacityTerm}, 0.6)); }
+
+#${EleID.BAR_TERMS} .${EleClass.CONTROL} {
+	white-space: pre;
+}
+
+#${EleID.BAR} {
+	& .${EleClass.CONTROL} {
+		& .${EleClass.CONTROL_PAD} {
+			display: flex;
+			height: 1.3em;
+			background: hsl(0 0% 90% / ${controlsInfo.barLook.opacityControl});
+			color: hsl(0 0% 0%);
+			border-style: none;
+			border-radius: ${controlsInfo.barLook.borderRadius};
+			box-shadow: 1px 1px 5px;
+		}
+		&.${EleClass.MENU_OPEN} .${EleClass.CONTROL_REVEAL} {
+			background: hsl(0 0% 100% / 0.6);
+		}
+		& .${EleClass.CONTROL_BUTTON}:not(:disabled) {
+			&:hover {
+				background: hsl(0 0% 65%);
+			}
+			&:active {
+				background: hsl(0 0% 50%);
+			}
+		}
+	}
+	&.${EleClass.DISABLED} .${EleClass.CONTROL} .${EleClass.CONTROL_PAD} {
+		background: hsl(0 0% 90% / min(${controlsInfo.barLook.opacityControl}, 0.4));
+	}
+	&:not(.${EleClass.DISABLED}) #${EleID.BAR_TERMS} .${EleClass.CONTROL} .${EleClass.CONTROL_PAD}.${EleClass.DISABLED} {
+		display: flex;
+		background: hsl(0 0% 80% / min(${controlsInfo.barLook.opacityTerm}, 0.6));
+	}
+	& > :not(#${EleID.BAR_TERMS}) > .${EleClass.DISABLED}:not(:focus-within) {
+		display: none;
+	}
+}
+
 /**/
 
-/* || Term Scroll Markers */
-#${getSel(ElementID.MARKER_GUTTER)}
-	{ display: block; position: fixed; right: 0; top: 0; width: 0; height: 100%; z-index: ${zIndexMax}; }
-#${getSel(ElementID.MARKER_GUTTER)} *
-	{ width: 16px; height: 1px; position: absolute; right: 0; border-left: solid hsl(0 0% 0% / 0.6) 1px; box-sizing: unset;
-	padding-right: 0; transition: padding-right 600ms; pointer-events: none; }
-#${getSel(ElementID.MARKER_GUTTER)} .${getSel(ElementClass.FOCUS)}
-	{ padding-right: 16px; transition: unset; }
+/* || Scroll Markers */
+
+#${EleID.MARKER_GUTTER} {
+	& {
+		display: block;
+		position: fixed;
+		right: 0;
+		top: 0;
+		width: 0;
+		height: 100%;
+		z-index: ${zIndexMax};
+	}
+	& * {
+		width: 16px;
+		height: 1px;
+		position: absolute;
+		right: 0; border-left: solid hsl(0 0% 0% / 0.6) 1px; box-sizing: unset;
+		padding-right: 0; transition: padding-right 600ms; pointer-events: none; }
+	& .${EleClass.FOCUS} {
+		padding-right: 16px;
+		transition: unset;
+	}
+}
+
 /**/
 
 /* || Term Highlights */
-.${getSel(ElementClass.FOCUS_CONTAINER)}
-	{ animation: ${getSel(AtRuleID.FLASH)} 1s; }
-${
-	controlsInfo.paintReplaceByClassic
-		? `
-mms-h
-	{ font: inherit; border-radius: 2px; visibility: visible; }
-.${getSel(ElementClass.FOCUS_CONTAINER)}
-	{ animation: ${getSel(AtRuleID.FLASH)} 1s; }`
-		: ""
+
+.${EleClass.FOCUS_CONTAINER} {
+	animation: ${AtRuleID.FLASH} 1s;
 }
-/**/
-	`) + `
+${controlsInfo.paintReplaceByClassic ? `
+${HIGHLIGHT_TAG} {
+	font: inherit;
+	border-radius: 2px;
+	visibility: visible;
+}
+.${EleClass.FOCUS_CONTAINER} {
+	animation: ${AtRuleID.FLASH} 1s;
+}` : ""}
+
+/**/`) + `
 ${
 	controlsInfo.paintReplaceByClassic || !paintUseExperimental
 		? ""
 		: paintUsePaintingFallback
 			? `
-#${getSel(ElementID.DRAW_CONTAINER)}
-	{ position: fixed; width: 100%; height: 100%; top: 100%; z-index: ${zIndexMin}; }
-#${getSel(ElementID.DRAW_CONTAINER)} > *
-	{ position: fixed; width: 100%; height: 100%; }`
-			: `/* || Term Highlight */
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)}
-~ body [markmysearch-h_id] [markmysearch-h_beneath]
-	{ background-color: transparent; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)} ~ body [markmysearch-h_id]
-	{ background-image: paint(markmysearch-highlights) !important; --markmysearch-styles: ${JSON.stringify((() => {
+
+#${EleID.DRAW_CONTAINER} {
+	& {
+		position: fixed;
+		width: 100%;
+		height: 100%;
+		top: 100%;
+		z-index: ${zIndexMin};
+	}
+	& > * {
+		position: fixed;
+		width: 100%;
+		height: 100%;
+	}
+}`
+			: `
+
+/* || Term Highlight */
+
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body [markmysearch-h_id] {
+	& [markmysearch-h_beneath] {
+		background-color: transparent;
+	}
+	& {
+		background-image: paint(markmysearch-highlights) !important; --markmysearch-styles: ${
+	JSON.stringify((() => {
 		const styles: TermSelectorStyles = {};
 		terms.forEach((term, i) => {
-			styles[term.selector] = {
+			styles[term.token] = {
 				hue: hues[i % hues.length],
 				cycle: Math.floor(i / hues.length),
 			};
 		});
 		return styles;
-	})())}; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)}
-~ body [markmysearch-h_id] > :not([markmysearch-h_id])
-	{ --markmysearch-styles: unset; --markmysearch-boxes: unset; }
+	})())};
+	}
+	& > :not([markmysearch-h_id]) {
+		--markmysearch-styles: unset;
+		--markmysearch-boxes: unset;
+	}
+}
+
 /**/`
 }
 ${
 	(!controlsInfo.paintReplaceByClassic && paintUseExperimental && paintUsePaintingFallback)
 		? `
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)}
-~ #${getSel(ElementID.DRAW_CONTAINER)} .${getSel(ElementClass.TERM)}
-	{ outline: 2px solid hsl(0 0% 0% / 0.1); outline-offset: -2px; border-radius: 2px; }`
+
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ #${EleID.DRAW_CONTAINER} .${EleClass.TERM} {
+	outline: 2px solid hsl(0 0% 0% / 0.1);
+	outline-offset: -2px;
+	border-radius: 2px;
+}`
 		: ""
 }
 
 /* || Transitions */
-@keyframes ${getSel(AtRuleID.MARKER_ON)}
-	{ from {} to { padding-right: 16px; }; }
-@keyframes ${getSel(AtRuleID.MARKER_OFF)}
-	{ from { padding-right: 16px; } to { padding-right: 0; }; }
-@keyframes ${getSel(AtRuleID.FLASH)}
-	{ from { background-color: hsl(0 0% 65% / 0.8); } to {}; }
+
+@keyframes ${AtRuleID.MARKER_ON} {
+	from {} to { padding-right: 16px; };
+}
+@keyframes ${AtRuleID.MARKER_OFF} {
+	from { padding-right: 16px; } to { padding-right: 0; };
+}
+@keyframes ${AtRuleID.FLASH} {
+	from { background-color: hsl(0 0% 65% / 0.8); } to {};
+}
+
+/**/
+
 	`;
 	terms.forEach((term, i) => {
 		const hue = hues[i % hues.length];
@@ -437,51 +619,59 @@ ${
 		term.hue = hue;
 		style.textContent += makeImportant(`
 /* || Term Highlights */
+
 ${controlsInfo.paintReplaceByClassic
 		? `
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)}
-~ body mms-h.${getSel(ElementClass.TERM, term.selector)},
-#${getSel(ElementID.BAR)}
-~ body .${getSel(ElementClass.FOCUS_CONTAINER)} mms-h.${getSel(ElementClass.TERM, term.selector)}
-	{ background: ${getBackgroundStyle(`hsl(${hue} 100% 60% / 0.4)`, `hsl(${hue} 100% 88% / 0.4)`)};
-	box-shadow: 0 0 0 1px hsl(${hue} 100% 20% / 0.35); }`
-		: paintUseExperimental && paintUsePaintingFallback
-			? `
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.HIGHLIGHTS_SHOWN)}
-~ #${getSel(ElementID.DRAW_CONTAINER)} .${getSel(ElementClass.TERM, term.selector)}
-	{ background: ${getBackgroundStyle(`hsl(${hue} 100% 60% / 0.4)`, `hsl(${hue} 100% 88% / 0.4)`)}; }`
-			: ""
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body ${HIGHLIGHT_TAG}.${getTermClass(term.token)},
+#${EleID.BAR} ~ body .${EleClass.FOCUS_CONTAINER} ${HIGHLIGHT_TAG}.${getTermClass(term.token)} {
+	background: ${getBackgroundStyle(`hsl(${hue} 100% 60% / 0.4)`, `hsl(${hue} 100% 88% / 0.4)`)};
+	box-shadow: 0 0 0 1px hsl(${hue} 100% 20% / 0.35);
+}` : (paintUseExperimental && paintUsePaintingFallback) ? `
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ #${EleID.DRAW_CONTAINER} .${getTermClass(term.token)} {
+	background: ${getBackgroundStyle(`hsl(${hue} 100% 60% / 0.4)`, `hsl(${hue} 100% 88% / 0.4)`)};
+}` : ""
 }
+
 /**/
 
 /* || Term Scroll Markers */
-#${getSel(ElementID.MARKER_GUTTER)} .${getSel(ElementClass.TERM, term.selector)}
-	{ background: hsl(${hue} 100% 44%); }
+
+#${EleID.MARKER_GUTTER} .${getTermClass(term.token)} {
+	background: hsl(${hue} 100% 44%);
+}
+
 /**/
 
 /* || Term Control Buttons */
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.TERM, term.selector)}
-.${getSel(ElementClass.CONTROL_PAD)}
-	{ background: ${getBackgroundStyle(
+
+#${EleID.BAR_TERMS} .${getTermClass(term.token)} .${EleClass.CONTROL_PAD} {
+	background: ${getBackgroundStyle(
 		`hsl(${hue} 70% 70% / ${controlsInfo.barLook.opacityTerm})`,
 		`hsl(${hue} 70% 88% / ${controlsInfo.barLook.opacityTerm})`,
-	)}; }
-#${getSel(ElementID.BAR)}.${getSel(ElementClass.DISABLED)}
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.TERM, term.selector)}
-.${getSel(ElementClass.CONTROL_PAD)}
-	{ background: ${getBackgroundStyle(
+	)};
+}
+
+#${EleID.BAR}.${EleClass.DISABLED} #${EleID.BAR_TERMS} .${getTermClass(term.token)} .${EleClass.CONTROL_PAD} {
+	background: ${getBackgroundStyle(
 		`hsl(${hue} 70% 70% / min(${controlsInfo.barLook.opacityTerm}, 0.4))`,
 		`hsl(${hue} 70% 88% / min(${controlsInfo.barLook.opacityTerm}, 0.4))`,
-	)}; }
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.TERM, term.selector)}
-.${getSel(ElementClass.CONTROL_BUTTON)}:hover:not(:disabled)
-	{ background: hsl(${hue} 70% 80%); }
-#${getSel(ElementID.BAR_TERMS)} .${getSel(ElementClass.TERM, term.selector)}
-.${getSel(ElementClass.CONTROL_BUTTON)}:active:not(:disabled)
-	{ background: hsl(${hue} 70% 70%); }
-#${getSel(ElementID.BAR_TERMS)}.${getSel(ElementClass.CONTROL_PAD, i)}
-.${getSel(ElementClass.TERM, term.selector)} .${getSel(ElementClass.CONTROL_PAD)}
-	{ background: hsl(${hue} 100% 90%); }
+	)};
+}
+
+#${EleID.BAR_TERMS} {
+	& .${getTermClass(term.token)} .${EleClass.CONTROL_BUTTON}:not(:disabled) {
+		&:hover {
+			background: hsl(${hue} 70% 80%);
+		}
+		&:active {
+			background: hsl(${hue} 70% 70%);
+		}
+	}
+	&.${getControlPadClass(i)} .${getTermClass(term.token)} .${EleClass.CONTROL_PAD} {
+		background: hsl(${hue} 100% 90%);
+	}
+}
+
 /**/
 		`);
 	});
@@ -543,10 +733,10 @@ const elementsRemakeUnfocusable = (root: HTMLElement | DocumentFragment = docume
 	if (!root.parentNode) {
 		return;
 	}
-	root.parentNode.querySelectorAll(`.${getSel(ElementClass.FOCUS_REVERT)}`)
+	root.parentNode.querySelectorAll(`.${EleClass.FOCUS_REVERT}`)
 		.forEach((element: HTMLElement) => {
 			element.tabIndex = -1;
-			element.classList.remove(getSel(ElementClass.FOCUS_REVERT));
+			element.classList.remove(EleClass.FOCUS_REVERT);
 		});
 };
 
@@ -579,9 +769,9 @@ const focusOnTermPaint = (() => {
 	};
 
 	return (stepNotJump: boolean, controlsInfo: ControlsInfo, reverse: boolean, term?: MatchTerm, nodeStart?: Node) => {
-		elementsPurgeClass(getSel(ElementClass.FOCUS_CONTAINER));
+		elementsPurgeClass(EleClass.FOCUS_CONTAINER);
 		const selection = document.getSelection() as Selection;
-		const bar = document.getElementById(getSel(ElementID.BAR)) as HTMLElement;
+		const bar = document.getElementById(EleID.BAR) as HTMLElement;
 		const nodeBegin = reverse ? getNodeFinal(document.body) : document.body;
 		const nodeSelected = selection ? selection.anchorNode : null;
 		const nodeFocused = document.activeElement
@@ -595,8 +785,8 @@ const focusOnTermPaint = (() => {
 				: nodeSelected ?? nodeBegin
 			);
 		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement) =>
-			(element[ElementProperty.INFO] as ElementInfo | undefined)?.flows.some(flow =>
-				term ? flow.boxesInfo.some(boxInfo => boxInfo.term.selector === term.selector) : flow.boxesInfo.length
+			(element[EleProperty.INFO] as ElementInfo | undefined)?.flows.some(flow =>
+				term ? flow.boxesInfo.some(boxInfo => boxInfo.term.token === term.token) : flow.boxesInfo.length
 			) && isVisible(element)
 				? NodeFilter.FILTER_ACCEPT
 				: NodeFilter.FILTER_SKIP
@@ -614,10 +804,10 @@ const focusOnTermPaint = (() => {
 			return;
 		}
 		if (!stepNotJump) {
-			element.classList.add(getSel(ElementClass.FOCUS_CONTAINER));
+			element.classList.add(EleClass.FOCUS_CONTAINER);
 		}
 		focusClosest(element, element =>
-			element[ElementProperty.INFO] && !!(element[ElementProperty.INFO] as ElementInfo).flows
+			element[EleProperty.INFO] && !!(element[EleProperty.INFO] as ElementInfo).flows
 		);
 		selection.setBaseAndExtent(element, 0, element, 0);
 		element.scrollIntoView({ behavior: stepNotJump ? "auto" : "smooth", block: "center" });
@@ -661,7 +851,7 @@ const insertTermInput = (() => {
 	const selectInput = (control: HTMLElement, shiftCaretRight?: boolean) => {
 		const input = control.querySelector("input");
 		if (!input) {
-			assert(false, "term input no select", "required element(s) not found", { control });
+			assert(false, "term input not selected", "required element(s) not found", { control });
 			return;
 		}
 		input.focus();
@@ -683,7 +873,7 @@ const insertTermInput = (() => {
 		const control = getControl(term) as HTMLElement;
 		const termInput = control.querySelector("input") as HTMLInputElement;
 		inputValue = inputValue ?? termInput.value;
-		const idx = getTermIdxFromArray(term, terms);
+		const idx = getTermIndexFromArray(term, terms);
 		// TODO standard method of avoiding race condition (arising from calling termsSet, which immediately updates controls)
 		if (replaces && inputValue === "") {
 			if (document.activeElement === termInput) {
@@ -716,7 +906,7 @@ const insertTermInput = (() => {
 		const replaces = !!term; // Whether a commit in this control replaces an existing term or appends a new one.
 		const control = getControl(term) as HTMLElement;
 		const termInput = control.querySelector("input") as HTMLInputElement;
-		const idx = replaces ? getTermIdxFromArray(term, terms) : terms.length;
+		const idx = replaces ? getTermIndexFromArray(term, terms) : terms.length;
 		shiftRight ??= (idxTarget ?? idx) > idx;
 		if (termInput.selectionStart !== termInput.selectionEnd
 			|| termInput.selectionStart !== (shiftRight ? termInput.value.length : 0)) {
@@ -738,58 +928,41 @@ const insertTermInput = (() => {
 	return (terms: MatchTerms, controlPad: HTMLElement, idxCode: TermChange.CREATE | number,
 		insertInput: (termInput: HTMLInputElement) => void) => {
 		const controlContent = controlPad
-			.getElementsByClassName(getSel(ElementClass.CONTROL_CONTENT))[0] as HTMLElement ?? controlPad;
+			.getElementsByClassName(EleClass.CONTROL_CONTENT)[0] as HTMLElement ?? controlPad;
 		const controlEdit = controlPad
-			.getElementsByClassName(getSel(ElementClass.CONTROL_EDIT))[0] as HTMLElement | undefined;
+			.getElementsByClassName(EleClass.CONTROL_EDIT)[0] as HTMLElement | undefined;
 		const term = terms[idxCode] as MatchTerm | undefined;
 		// Whether a commit in this control replaces an existing term or appends a new one.
 		const replaces = idxCode !== TermChange.CREATE;
 		const input = document.createElement("input");
 		input.type = "text";
+		input.classList.add(EleClass.CONTROL_INPUT);
 		// Inputs should not be focusable unless user has already focused bar. (0)
-		if (!document.activeElement || !document.activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+		if (!document.activeElement || !document.activeElement.closest(`#${EleID.BAR}`)) {
 			input.tabIndex = -1;
 		}
 		const resetInput = (termText = controlContent.textContent as string) => {
 			input.value = replaces ? termText : "";
 		};
-		input.addEventListener("focusin", () => {
-			if (input.classList.contains(getSel(ElementClass.OVERRIDE_FOCUS))) {
-				return; // Focus has been delegated to another element and will be on the input when this class is removed.
-			}
-			resetInput();
-			termControlInputsVisibilityReset();
-			input.classList.add(getSel(ElementClass.OVERRIDE_VISIBILITY));
-		});
-		input.addEventListener("focusout", () => {
-			if (!input.classList.contains(getSel(ElementClass.OVERRIDE_FOCUS))) {
-				// Focus has been lost, not delegated to another element.
-				commit(term, terms);
-			}
-		});
-		input.addEventListener("keyup", event => {
-			// First focus of an input does not allow immediate full-text selection.
-			if (event.key === "Tab") { // Simulate (delegated) if Tab was used to reach the input.
-				selectInputTextAll(input);
-			}
-		});
 		const show = (event: MouseEvent) => {
 			event.preventDefault();
 			input.focus();
 			input.select();
-			selectInputTextAll(input);
+			if (document.getSelection()?.toString() === input.value) {
+				setTimeout(() => {
+					input.select();
+				});
+			}
 		};
-		const hide = () => {
-			input.blur();
-		};
+		const hide = () => input.blur();
 		if (controlEdit) {
 			controlEdit.addEventListener("click", event => {
-				if (!input.classList.contains(getSel(ElementClass.OVERRIDE_VISIBILITY)) || getComputedStyle(input).width === "0") {
-					show(event);
-				} else {
+				if (inputSize) { // Input is shown; currently a delete button.
 					input.value = "";
 					commit(term, terms);
 					hide();
+				} else { // Input is hidden; currently an edit button.
+					show(event);
 				}
 			});
 			controlEdit.addEventListener("contextmenu", event => {
@@ -816,7 +989,6 @@ const insertTermInput = (() => {
 			case "Enter": {
 				if (event.shiftKey) {
 					hide();
-					termControlInputsVisibilityReset();
 				} else {
 					const inputValue = input.value;
 					resetInput(inputValue);
@@ -827,7 +999,6 @@ const insertTermInput = (() => {
 			case "Escape": {
 				resetInput();
 				hide();
-				termControlInputsVisibilityReset();
 				return;
 			}
 			case "ArrowLeft":
@@ -845,11 +1016,41 @@ const insertTermInput = (() => {
 					return;
 				}
 				event.preventDefault();
-				openTermOptionMenu(term);
+				input.classList.add(EleClass.OPENED_MENU);
+				openTermOptionList(term);
 				return;
-			}
+			}}
+		});
+		input.addEventListener("keyup", event => {
+			event.stopPropagation();
+			if (event.key === "Tab") {
+				input.select();
 			}
 		});
+		input.addEventListener("focusin", () => {
+			setTimeout(() => {
+				input.select();
+			});
+		});
+		// Potential future improvement to mitigate cross-browser quirk where the first time an input is focused, it cannot be selected.
+		//input.addEventListener("focusout", event => {
+		//	const newFocus = event.relatedTarget as Element | null;
+		//	if (newFocus?.closest(`#${EleID.BAR}`)) {
+		//		input.classList.add(EleClass.WAS_FOCUSED);
+		//	}
+		//});
+		let inputSize = 0;
+		new ResizeObserver(entries => {
+			const inputSizeNew = entries[0]?.contentBoxSize[0]?.inlineSize ?? 0;
+			if (inputSizeNew !== inputSize) {
+				if (inputSizeNew) {
+					resetInput();
+				} else {
+					commit(term, terms);
+				}
+			}
+			inputSize = inputSizeNew;
+		}).observe(input);
 		insertInput(input);
 		return input;
 	};
@@ -861,7 +1062,7 @@ const insertTermInput = (() => {
  * @param terms Terms to search in.
  * @returns The append term constant index if not found, the term's index otherwise.
  */
-const getTermIdxFromArray = (term: MatchTerm | undefined, terms: MatchTerms): TermChange.CREATE | number =>
+const getTermIndexFromArray = (term: MatchTerm | undefined, terms: MatchTerms): TermChange.CREATE | number =>
 	term ? terms.indexOf(term) : TermChange.CREATE
 ;
 
@@ -874,9 +1075,9 @@ const getTermIdxFromArray = (term: MatchTerm | undefined, terms: MatchTerms): Te
  * OR the append term control otherwise.
  */
 const getControl = (term?: MatchTerm, idx?: number): Element | null => {
-	const barTerms = document.getElementById(getSel(ElementID.BAR_TERMS)) as HTMLElement;
+	const barTerms = document.getElementById(EleID.BAR_TERMS) as HTMLElement;
 	return (idx === undefined && term
-		? barTerms.getElementsByClassName(getSel(ElementClass.TERM, term.selector))[0]
+		? barTerms.getElementsByClassName(getTermClass(term.token))[0]
 		: idx === undefined || idx >= barTerms.children.length
 			? getControlAppendTerm()
 			: Array.from(barTerms.children)[idx ?? (barTerms.childElementCount - 1)] ?? null
@@ -888,16 +1089,7 @@ const getControl = (term?: MatchTerm, idx?: number): Element | null => {
  * @returns The control if present, `null` otherwise.
  */
 const getControlAppendTerm = (): Element | null =>
-	(document.getElementById(getSel(ElementID.BAR_RIGHT)) as HTMLElement).firstElementChild
-;
-
-/**
- * Selects all of the text in an input. Does not affect focus.
- * Mainly a helper for mitigating a Chromium bug which causes `select()` for an input's initial focus to not select all text.
- * @param input An input element to select the text of.
- */
-const selectInputTextAll = (input: HTMLInputElement) =>
-	input.setSelectionRange(0, input.value.length)
+	(document.getElementById(EleID.BAR_RIGHT) as HTMLElement).firstElementChild
 ;
 
 /**
@@ -905,16 +1097,20 @@ const selectInputTextAll = (input: HTMLInputElement) =>
  * @param term A term to get the occurrence count for.
  * @returns The occurrence count for the term.
  */
-const getTermOccurrenceCount = (term: MatchTerm, controlsInfo: ControlsInfo, checkExistsOnly = false): number => controlsInfo.paintReplaceByClassic
+const getTermOccurrenceCount = (
+	term: MatchTerm,
+	controlsInfo: ControlsInfo,
+	checkExistsOnly = false,
+): number => controlsInfo.paintReplaceByClassic
 	? (() => { // Increasingly inaccurate as highlights elements are more often split.
-		const occurrences = Array.from(document.body.getElementsByClassName(getSel(ElementClass.TERM, term.selector)));
+		const occurrences = Array.from(document.body.getElementsByClassName(getTermClass(term.token)));
 		//const matches = occurrences.map(occurrence => occurrence.textContent).join("").match(term.pattern);
 		//return matches ? matches.length : 0; // Works poorly in situations such as matching whole words.
 		return occurrences.length; // Poor and changeable heuristic, but so far the most reliable efficient method.
 	})()
 	: ((): number => {
 		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, element =>
-			(ElementProperty.INFO in element) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT);
+			(EleProperty.INFO in element) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT);
 		let count = 0;
 		let element: Element;
 		// eslint-disable-next-line no-cond-assign
@@ -922,7 +1118,7 @@ const getTermOccurrenceCount = (term: MatchTerm, controlsInfo: ControlsInfo, che
 			if (!element) {
 				break;
 			}
-			(element[ElementProperty.INFO] as ElementInfo).flows.forEach(flow => {
+			(element[EleProperty.INFO] as ElementInfo).flows.forEach(flow => {
 				count += flow.boxesInfo.filter(boxInfo => boxInfo.term === term).length;
 			});
 			if (checkExistsOnly && count > 0) {
@@ -939,8 +1135,8 @@ const getTermOccurrenceCount = (term: MatchTerm, controlsInfo: ControlsInfo, che
  */
 const updateTermOccurringStatus = (term: MatchTerm, controlsInfo: ControlsInfo) => {
 	const controlPad = (getControl(term) as HTMLElement)
-		.getElementsByClassName(getSel(ElementClass.CONTROL_PAD))[0] as HTMLElement;
-	controlPad.classList.toggle(getSel(ElementClass.DISABLED), !getTermOccurrenceCount(term, controlsInfo, true));
+		.getElementsByClassName(EleClass.CONTROL_PAD)[0] as HTMLElement;
+	controlPad.classList.toggle(EleClass.DISABLED, !getTermOccurrenceCount(term, controlsInfo, true));
 };
 
 /**
@@ -949,9 +1145,9 @@ const updateTermOccurringStatus = (term: MatchTerm, controlsInfo: ControlsInfo) 
  */
 const updateTermTooltip = (term: MatchTerm, controlsInfo: ControlsInfo) => {
 	const controlPad = (getControl(term) as HTMLElement)
-		.getElementsByClassName(getSel(ElementClass.CONTROL_PAD))[0] as HTMLElement;
+		.getElementsByClassName(EleClass.CONTROL_PAD)[0] as HTMLElement;
 	const controlContent = controlPad
-		.getElementsByClassName(getSel(ElementClass.CONTROL_CONTENT))[0] as HTMLElement;
+		.getElementsByClassName(EleClass.CONTROL_CONTENT)[0] as HTMLElement;
 	const occurrenceCount = getTermOccurrenceCount(term, controlsInfo);
 	controlContent.title = `${occurrenceCount} ${occurrenceCount === 1 ? "match" : "matches"} in page${
 		!occurrenceCount || !term.command ? ""
@@ -961,28 +1157,16 @@ const updateTermTooltip = (term: MatchTerm, controlsInfo: ControlsInfo) => {
 };
 
 /**
- * Gets the term match type identifier for a match option.
- * @param classList The class list of a match option.
- * @returns The corresponding match type identifier string.
- */
-const getTermOptionMatchType = (classList: Array<string>): keyof MatchMode =>
-	(classList.find(className => {
-		const parts = className.split("-");
-		return parts[1] === ElementClass.OPTION && parts[2];
-	})?.split("-")[2] ?? "") as keyof MatchMode
-;
-
-/**
  * Updates the class list of a control to reflect the matching options of its term.
  * @param mode An object of term matching mode flags.
  * @param classList The control element class list for a term.
  */
 const updateTermControlMatchModeClassList = (mode: MatchMode, classList: DOMTokenList) => {
-	classList.toggle(getSel(ElementClass.MATCH_REGEX), mode.regex);
-	classList.toggle(getSel(ElementClass.MATCH_CASE), mode.case);
-	classList.toggle(getSel(ElementClass.MATCH_STEM), mode.stem);
-	classList.toggle(getSel(ElementClass.MATCH_WHOLE), mode.whole);
-	classList.toggle(getSel(ElementClass.MATCH_DIACRITICS), mode.diacritics);
+	classList.toggle(EleClass.MATCH_REGEX, mode.regex);
+	classList.toggle(EleClass.MATCH_CASE, mode.case);
+	classList.toggle(EleClass.MATCH_STEM, mode.stem);
+	classList.toggle(EleClass.MATCH_WHOLE, mode.whole);
+	classList.toggle(EleClass.MATCH_DIACRITICS, mode.diacritics);
 };
 
 /**
@@ -991,11 +1175,11 @@ const updateTermControlMatchModeClassList = (mode: MatchMode, classList: DOMToke
  * @returns The matching options for the term.
  */
 const getTermControlMatchModeFromClassList = (classList: DOMTokenList): MatchMode => ({
-	regex: classList.contains(getSel(ElementClass.MATCH_REGEX)),
-	case: classList.contains(getSel(ElementClass.MATCH_CASE)),
-	stem: classList.contains(getSel(ElementClass.MATCH_STEM)),
-	whole: classList.contains(getSel(ElementClass.MATCH_WHOLE)),
-	diacritics: classList.contains(getSel(ElementClass.MATCH_DIACRITICS)),
+	regex: classList.contains(EleClass.MATCH_REGEX),
+	case: classList.contains(EleClass.MATCH_CASE),
+	stem: classList.contains(EleClass.MATCH_STEM),
+	whole: classList.contains(EleClass.MATCH_WHOLE),
+	diacritics: classList.contains(EleClass.MATCH_DIACRITICS),
 });
 
 /**
@@ -1006,18 +1190,14 @@ const getTermControlMatchModeFromClassList = (classList: DOMTokenList): MatchMod
  */
 const refreshTermControl = (term: MatchTerm, idx: number, highlightTags: HighlightTags, controlsInfo: ControlsInfo) => {
 	const control = getControl(undefined, idx) as HTMLElement;
-	control.className = "";
-	control.classList.add(getSel(ElementClass.CONTROL));
-	control.classList.add(getSel(ElementClass.TERM, term.selector));
+	control.classList.remove(Array.from(control.classList).find(className => className.startsWith(getTermClass(""))) ?? "-");
+	control.classList.add(getTermClass(term.token));
+	control.classList.add(EleClass.CONTROL, getTermClass(term.token));
 	updateTermControlMatchModeClassList(term.matchMode, control.classList);
-	const controlContent = control.getElementsByClassName(getSel(ElementClass.CONTROL_CONTENT))[0] as HTMLElement;
+	const controlContent = control.getElementsByClassName(EleClass.CONTROL_CONTENT)[0] as HTMLElement;
 	controlContent.onclick = event => // Overrides previous event handler in case of new term.
 		focusOnTermJump(controlsInfo, highlightTags, event.shiftKey, term);
 	controlContent.textContent = term.phrase;
-	// TODO make function
-	control.querySelectorAll(`.${getSel(ElementClass.OPTION)}`).forEach(option =>
-		(option.querySelector("input") as HTMLInputElement).checked = term.matchMode[getTermOptionMatchType(Array.from(option.classList))]
-	);
 };
 
 /**
@@ -1030,142 +1210,199 @@ const removeTermControl = (idx: number) => {
 
 /**
  * Creates a clickable element to toggle one of the matching options for a term.
- * @param term The term for which to create a matching option.
+ * @param matchMode The match mode object to use.
+ * @param matchType The match type of this option.
  * @param text Text content for the option, which is also used to determine the matching mode it controls.
  * @param onActivated A function, taking the identifier for the match option, to execute each time the option is activated.
  * @returns The resulting option element.
  */
-const createTermOption = (term: MatchTerm, matchType: keyof MatchMode, text: string,
-	onActivated: (matchType: string) => void): HTMLElement => {
-	const option = document.createElement("span");
-	option.classList.add(getSel(ElementClass.OPTION));
-	option.classList.add(getSel(ElementClass.OPTION, matchType));
-	const id = getSel(ElementID.INPUT, getIdSequential.next().value.toString());
+const createTermOption = (
+	matchMode: MatchMode,
+	matchType: keyof MatchMode,
+	text: string,
+	onActivated: (matchType: string, checked: boolean) => void,
+) => {
+	const option = document.createElement("label");
+	option.classList.add(EleClass.OPTION, getMatchModeOptionClass(matchType));
+	const id = getInputIdSequential();
+	option.htmlFor = id;
 	const checkbox = document.createElement("input");
-	checkbox.id = id;
 	checkbox.type = "checkbox";
-	checkbox.checked = term.matchMode[matchType];
-	checkbox.addEventListener("change", () => {
-		onActivated(matchType);
+	checkbox.id = id;
+	checkbox.checked = matchMode[matchType];
+	checkbox.tabIndex = -1;
+	checkbox.addEventListener("click", () => {
+		onActivated(matchType, checkbox.checked);
 	});
 	checkbox.addEventListener("keydown", event => {
 		if (event.key === " ") {
-			event.stopPropagation();
+			checkbox.click(); // Why is this not happening by default anyway?
+			event.preventDefault();
 		}
 	});
-	const label = document.createElement("label");
-	label.htmlFor = id;
+	const label = document.createElement("span");
 	label.textContent = text;
-	label.addEventListener("mouseup", () => {
-		if (!label.matches(":active")) {
-			onActivated(matchType);
+	option.addEventListener("mousedown", event => {
+		event.preventDefault(); // Prevent the menu from perceiving a loss in focus (and closing) the second time an option is clicked.
+	});
+	option.addEventListener("mouseup", () => {
+		if (!option.closest(`.${EleClass.MENU_OPEN}`)) { // So that the user can "pulldown" the menu and release over an option.
+			checkbox.click();
 		}
 	});
-	label.addEventListener("click", () => onActivated(matchType));
 	option.appendChild(checkbox);
 	option.appendChild(label);
-	return option;
-};
-
-/**
- * Moves focus temporarily from a term input to a target element. Term inputs normally commit when unfocused,
- * but this method ensures it is considered a delegation of focus so will not cause changes to be committed.
- * Accordingly, focus is returned to the input once lost from the target.
- * @param input The term input from which to delegate focus.
- * @param target The element which will hold focus until returned to the input.
- */
-const delegateFocusFromTermInput = (input: HTMLInputElement, target: HTMLElement) => {
-	if (document.activeElement === input) {
-		input.classList.add(getSel(ElementClass.OVERRIDE_FOCUS));
-	}
-	target.focus();
-	if (input.classList.contains(getSel(ElementClass.OVERRIDE_FOCUS))) {
-		const returnFocus = () => {
-			target.removeEventListener("blur", returnFocus);
-			input.focus();
-			input.classList.remove(getSel(ElementClass.OVERRIDE_FOCUS));
-		};
-		target.addEventListener("blur", returnFocus);
-	}
+	return {
+		optionElement: option,
+		toggle: () => {
+			checkbox.click();
+		},
+		makeFocusable: (focusable: boolean) => {
+			if (focusable) {
+				checkbox.removeAttribute("tabindex");
+			} else {
+				checkbox.tabIndex = -1;
+			}
+		},
+	};
 };
 
 /**
  * Creates a menu structure containing clickable elements to individually toggle the matching options for a term.
  * @param term The term for which to create a menu.
- * @param terms Terms being controlled and highlighted.
- * @param onActivated A function, taking the identifier for a match option, to execute each time the option is activated.
+ * @param matchMode The match mode object to use.
  * @param controlsInfo Details of controls being inserted.
+ * @param onActivated A function, taking the identifier for a match option, to execute each time the option is activated.
  * @returns The resulting menu element.
  */
-const createTermOptionMenu = (
-	term: MatchTerm,
-	terms: MatchTerms,
+const createTermOptionList = (
+	term: MatchTerm | undefined,
+	matchMode: MatchMode,
 	controlsInfo: ControlsInfo,
-	onActivated = (matchType: string) => {
-		const termUpdate = Object.assign({}, term);
-		termUpdate.matchMode = Object.assign({}, termUpdate.matchMode);
-		termUpdate.matchMode[matchType] = !termUpdate.matchMode[matchType];
-		termsSet(terms.map(termCurrent => termCurrent === term ? termUpdate : termCurrent));
-	},
+	onActivated: (matchType: string, checked: boolean) => void,
 ): { optionList: HTMLElement, controlReveal: HTMLButtonElement } => {
-	const termIsValid = terms.includes(term); // If virtual and used for appending terms, this will be `false`.
 	const optionList = document.createElement("span");
-	optionList.classList.add(getSel(ElementClass.OPTION_LIST));
-	optionList.appendChild(createTermOption(term, "case", "Case Sensitive", onActivated));
-	optionList.appendChild(createTermOption(term, "whole", "Whole Word", onActivated));
-	optionList.appendChild(createTermOption(term, "stem", "Stem Word", onActivated));
-	optionList.appendChild(createTermOption(term, "diacritics", "Diacritics", onActivated));
-	optionList.appendChild(createTermOption(term, "regex", "Regex Mode", onActivated));
-	const handleKeyEvent = (event: KeyboardEvent, executeResult = true) => {
+	optionList.classList.add(EleClass.OPTION_LIST);
+	const options = (() => {
+		const options: Array<{ matchType: keyof MatchMode, title: string }> = [
+			{ matchType: "case", title: "Case Sensitive" },
+			{ matchType: "whole", title: "Whole Word" },
+			{ matchType: "stem", title: "Stem Word" },
+			{ matchType: "diacritics", title: "Diacritics" },
+			{ matchType: "regex", title: "Regex Mode" },
+		];
+		return options.map(({ matchType, title }) => {
+			const { optionElement, toggle, makeFocusable } = createTermOption(matchMode, matchType, title, onActivated);
+			optionList.appendChild(optionElement);
+			return {
+				matchType,
+				title,
+				toggle,
+				makeFocusable,
+			};
+		});
+	})();
+	const closeList = (moveFocus: boolean) => {
+		const input = document.querySelector(`#${EleID.BAR} .${EleClass.OPENED_MENU}`) as HTMLElement | null;
+		if (input) {
+			if (moveFocus) {
+				input.focus();
+			}
+		} else if (moveFocus) {
+			const focus = document.activeElement as HTMLElement | null;
+			if (optionList.contains(focus)) {
+				focus?.blur();
+			}
+		}
+		getControl(term)?.classList.remove(EleClass.MENU_OPEN);
+	};
+	const stopKeyEvent = (event: KeyboardEvent) => {
+		event.stopPropagation();
 		if (event.key === "Tab") {
-			event.stopPropagation();
 			return;
 		}
 		event.preventDefault();
-		if (!executeResult) {
-			return;
-		}
-		if (event.key === "Escape") {
-			if (document.activeElement && document.activeElement["blue"]) {
-				document.activeElement["blur"]();
-			}
-			return;
-		} else if (event.key === " " || event.key.length !== 1) {
-			return;
-		}
-		Array.from(optionList.querySelectorAll(`.${getSel(ElementClass.OPTION)} label`)).some((option: HTMLButtonElement) => {
-			if ((option.textContent ?? "").toLowerCase().startsWith(event.key)) {
-				option.click();
-				return true;
-			}
-			return false;
-		});
-		optionList.blur();
 	};
-	optionList.addEventListener("keydown", event => handleKeyEvent(event, false));
-	optionList.addEventListener("keyup", event => handleKeyEvent(event));
-	optionList.addEventListener("focusout", () => {
-		if (!optionList.contains(document.activeElement)) {
-			optionList.removeAttribute("tabindex");
+	const handleKeyEvent = (event: KeyboardEvent) => {
+		stopKeyEvent(event);
+		if (event.key === "Escape") {
+			closeList(true);
+		} else if (event.key.startsWith("Arrow")) {
+			if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+				const down = event.key === "ArrowDown";
+				const checkboxes = Array.from(optionList.querySelectorAll("input[type='checkbox']")) as Array<HTMLInputElement>;
+				let idx = checkboxes.findIndex(checkbox => checkbox === document.activeElement);
+				if (idx === -1) {
+					idx = down ? 0 : (checkboxes.length - 1);
+				} else {
+					idx = (idx + (down ? 1 : -1) + checkboxes.length) % checkboxes.length;
+				}
+				checkboxes[idx].focus();
+			} else {
+				// TODO move to the menu of the next term
+			}
+		} else if (/\b\w\b/.test(event.key)) {
+			options.some(option => {
+				if (option.title.toLowerCase().startsWith(event.key)) {
+					option.toggle();
+					return true;
+				}
+				return false;
+			});
+			closeList(true);
+		}
+	};
+	optionList.addEventListener("keydown", handleKeyEvent);
+	optionList.addEventListener("keyup", stopKeyEvent);
+	const forgetOpenedMenu = () => {
+		document.querySelectorAll(`#${EleID.BAR} .${EleClass.OPENED_MENU}`).forEach(input => {
+			input.classList.remove(EleClass.OPENED_MENU);
+		});
+	};
+	optionList.addEventListener("focusin", () => {
+		options.forEach(option => option.makeFocusable(true));
+	});
+	optionList.addEventListener("focusout", event => {
+		optionList.removeAttribute("tabindex");
+		const newFocus = event.relatedTarget as Element | null;
+		if (optionList.contains(newFocus)) {
+			return;
+		}
+		options.forEach(option => option.makeFocusable(false));
+		if (newFocus?.classList.contains(EleClass.CONTROL_REVEAL)) {
+			closeList(false);
+		} else {
+			closeList(true);
+			forgetOpenedMenu();
 		}
 	});
 	const controlReveal = document.createElement("button");
 	controlReveal.type = "button";
-	controlReveal.classList.add(getSel(ElementClass.CONTROL_BUTTON));
-	controlReveal.classList.add(getSel(ElementClass.CONTROL_REVEAL));
+	controlReveal.classList.add(EleClass.CONTROL_BUTTON, EleClass.CONTROL_REVEAL);
 	controlReveal.tabIndex = -1;
 	controlReveal.disabled = !controlsInfo.barLook.showRevealIcon;
+	controlReveal.addEventListener("mousedown", () => {
+		const control = getControl(term);
+		// If menu was open, it is about to be "just closed" because the mousedown will close it.
+		// If menu was closed, remove "just closed" class if present.
+		control?.classList.toggle(
+			EleClass.MENU_JUST_CLOSED_BY_BUTTON, // *just closed "by button"* because this class is only applied here.
+			control.classList.contains(EleClass.MENU_OPEN),
+		);
+		closeList(true);
+		forgetOpenedMenu();
+	});
 	controlReveal.addEventListener("click", () => {
-		const input = controlReveal.parentElement ? controlReveal.parentElement.querySelector("input") : null;
-		const willFocusInput = input ? input.getBoundingClientRect().width > 0 : false;
-		termControlInputsVisibilityReset();
-		if (input && willFocusInput) {
-			input.focus();
+		if (controlReveal.closest(`.${EleClass.MENU_JUST_CLOSED_BY_BUTTON}`)) {
+			return;
 		}
-		openTermOptionMenu(termIsValid ? term : undefined);
+		const input = document.querySelector(`#${EleID.BAR} .${EleClass.WAS_FOCUSED}`) as HTMLElement | null;
+		input?.classList.add(EleClass.OPENED_MENU);
+		openTermOptionList(term);
 	});
 	const controlRevealToggle = document.createElement("img");
 	controlRevealToggle.src = chrome.runtime.getURL("/icons/reveal.svg");
+	controlRevealToggle.draggable = false;
 	controlReveal.appendChild(controlRevealToggle);
 	return { optionList, controlReveal };
 };
@@ -1174,20 +1411,18 @@ const createTermOptionMenu = (
  * Opens and focuses the menu of matching options for a term, allowing the user to toggle matching modes.
  * @param term The term for which to open a matching options menu.
  */
-const openTermOptionMenu = (term: MatchTerm | undefined) => {
+const openTermOptionList = (term: MatchTerm | undefined) => {
 	const control = getControl(term);
-	const input = control ? control.querySelector("input") : null;
-	const optionList = control ? control.querySelector(`.${getSel(ElementClass.OPTION_LIST)}`) as HTMLElement | null : null;
-	if (!input || !optionList) {
-		assert(false, "term option menu no open", "required element(s) not found",
+	const input = control?.querySelector("input");
+	const optionList = control?.querySelector(`.${EleClass.OPTION_LIST}`) as HTMLElement | null;
+	if (!control || !input || !optionList) {
+		assert(false, "term option menu not opened", "required element(s) not found",
 			{ term: (term ? term : "term appender") });
 		return;
 	}
-	delegateFocusFromTermInput(input, optionList);
-	optionList.classList.add(getSel(ElementClass.OVERRIDE_VISIBILITY));
+	control.classList.add(EleClass.MENU_OPEN);
 	optionList.tabIndex = 0;
 	optionList.focus();
-	optionList.classList.remove(getSel(ElementClass.OVERRIDE_VISIBILITY));
 };
 
 /**
@@ -1199,18 +1434,31 @@ const openTermOptionMenu = (term: MatchTerm | undefined) => {
  * @param controlsInfo Details of controls inserted.
  * @param highlightTags Element tags which are rejected from highlighting OR allow flows of text nodes to leave.
  */
-const insertTermControl = (terms: MatchTerms, idx: number, command: string, commandReverse: string,
-	controlsInfo: ControlsInfo, highlightTags: HighlightTags) => {
+const insertTermControl = (
+	terms: MatchTerms,
+	idx: number,
+	command: string,
+	commandReverse: string,
+	controlsInfo: ControlsInfo,
+	highlightTags: HighlightTags,
+) => {
 	const term = terms[idx >= 0 ? idx : (terms.length + idx)] as MatchTerm;
-	const { optionList, controlReveal } = createTermOptionMenu(term, terms, controlsInfo);
+	const { optionList, controlReveal } = createTermOptionList(term,
+		term.matchMode,
+		controlsInfo,
+		(matchType: string, checked: boolean) => {
+			const termUpdate = Object.assign({}, term);
+			termUpdate.matchMode = Object.assign({}, termUpdate.matchMode);
+			termUpdate.matchMode[matchType] = checked;
+			termsSet(terms.map(termCurrent => termCurrent === term ? termUpdate : termCurrent));
+		},
+	);
 	const controlPad = document.createElement("span");
-	controlPad.classList.add(getSel(ElementClass.CONTROL_PAD));
-	controlPad.classList.add(getSel(ElementClass.DISABLED));
+	controlPad.classList.add(EleClass.CONTROL_PAD, EleClass.DISABLED);
 	controlPad.appendChild(controlReveal);
 	const controlContent = document.createElement("button");
 	controlContent.type = "button";
-	controlContent.classList.add(getSel(ElementClass.CONTROL_BUTTON));
-	controlContent.classList.add(getSel(ElementClass.CONTROL_CONTENT));
+	controlContent.classList.add(EleClass.CONTROL_BUTTON, EleClass.CONTROL_CONTENT);
 	controlContent.tabIndex = -1;
 	controlContent.textContent = term.phrase;
 	controlContent.onclick = () => { // Hack: event handler property used so that the listener is not duplicated.
@@ -1222,29 +1470,28 @@ const insertTermControl = (terms: MatchTerms, idx: number, command: string, comm
 	controlPad.appendChild(controlContent);
 	const controlEdit = document.createElement("button");
 	controlEdit.type = "button";
-	controlEdit.classList.add(getSel(ElementClass.CONTROL_BUTTON));
-	controlEdit.classList.add(getSel(ElementClass.CONTROL_EDIT));
+	controlEdit.classList.add(EleClass.CONTROL_BUTTON, EleClass.CONTROL_EDIT);
 	controlEdit.tabIndex = -1;
 	controlEdit.disabled = !controlsInfo.barLook.showEditIcon;
 	const controlEditChange = document.createElement("img");
-	const controlEditRemove = document.createElement("img");
+	controlEditChange.classList.add(EleClass.PRIMARY);
 	controlEditChange.src = chrome.runtime.getURL("/icons/edit.svg");
+	controlEditChange.draggable = false;
+	const controlEditRemove = document.createElement("img");
+	controlEditRemove.classList.add(EleClass.SECONDARY);
 	controlEditRemove.src = chrome.runtime.getURL("/icons/delete.svg");
-	controlEditChange.classList.add(getSel(ElementClass.PRIMARY));
-	controlEditRemove.classList.add(getSel(ElementClass.SECONDARY));
-	controlEdit.appendChild(controlEditChange);
-	controlEdit.appendChild(controlEditRemove);
+	controlEditRemove.draggable = false;
+	controlEdit.append(controlEditChange, controlEditRemove);
 	controlPad.appendChild(controlEdit);
 	insertTermInput(terms, controlPad, idx, input => controlPad.insertBefore(input, controlEdit));
 	term.command = command;
 	term.commandReverse = commandReverse;
 	const control = document.createElement("span");
-	control.classList.add(getSel(ElementClass.CONTROL));
-	control.classList.add(getSel(ElementClass.TERM, term.selector));
+	control.classList.add(EleClass.CONTROL, getTermClass(term.token));
 	control.appendChild(controlPad);
 	control.appendChild(optionList);
 	updateTermControlMatchModeClassList(term.matchMode, control.classList);
-	(document.getElementById(getSel(ElementID.BAR_TERMS)) as HTMLElement).appendChild(control);
+	(document.getElementById(EleID.BAR_TERMS) as HTMLElement).appendChild(control);
 };
 
 /**
@@ -1270,11 +1517,11 @@ const getTermCommands = (commands: BrowserCommands): { down: Array<string>, up: 
 };
 
 const controlGetClass = (controlName: ControlButtonName) =>
-	getSel(ElementClass.CONTROL, controlName)
+	EleClass.CONTROL + "-" + controlName
 ;
 
 const controlVisibilityUpdate = (controlName: ControlButtonName, controlsInfo: ControlsInfo, terms: MatchTerms) => {
-	const control = document.querySelector(`#${getSel(ElementID.BAR)} .${controlGetClass(controlName)}`);
+	const control = document.querySelector(`#${EleID.BAR} .${controlGetClass(controlName)}`);
 	if (control) {
 		const value = controlsInfo.barControlsShown[controlName];
 		const shown = controlName === "replaceTerms"
@@ -1283,7 +1530,7 @@ const controlVisibilityUpdate = (controlName: ControlButtonName, controlsInfo: C
 				|| !controlsInfo.termsOnHold.every(termOnHold => terms.find(term => term.phrase === termOnHold.phrase))
 			))
 			: value;
-		control.classList.toggle(getSel(ElementClass.DISABLED), !shown);
+		control.classList.toggle(EleClass.DISABLED, !shown);
 	}
 };
 
@@ -1313,23 +1560,38 @@ const controlsInsert = (() => {
 		const controlInsertWithInfo = (controlName: ControlButtonName, info: ControlButtonInfo,
 			hideWhenInactive: boolean) => {
 			const control = document.createElement("span");
-			control.classList.add(getSel(ElementClass.CONTROL), controlGetClass(controlName));
+			control.classList.add(EleClass.CONTROL, controlGetClass(controlName));
 			(info.controlClasses ?? []).forEach(elementClass =>
-				control.classList.add(getSel(elementClass))
+				control.classList.add(elementClass)
 			);
 			control.tabIndex = -1;
 			const pad = document.createElement("span");
-			pad.classList.add(getSel(ElementClass.CONTROL_PAD));
+			pad.classList.add(EleClass.CONTROL_PAD);
 			pad.tabIndex = -1;
 			const button = document.createElement("button");
 			button.type = "button";
+			button.classList.add(EleClass.CONTROL_BUTTON);
 			button.tabIndex = -1;
-			if (info.buttonClass) {
-				button.classList.add(getSel(info.buttonClass));
+			if (info.buttonClasses) {
+				info.buttonClasses.forEach(className => {
+					button.classList.add(className);
+				});
 			}
 			if (info.path) {
 				const image = document.createElement("img");
+				if (info.pathSecondary) {
+					image.classList.add(EleClass.PRIMARY);
+				}
 				image.src = chrome.runtime.getURL(info.path);
+				image.draggable = false;
+				button.appendChild(image);
+			}
+			if (info.pathSecondary) {
+				// TODO make function
+				const image = document.createElement("img");
+				image.classList.add(EleClass.SECONDARY);
+				image.src = chrome.runtime.getURL(info.pathSecondary);
+				image.draggable = false;
 				button.appendChild(image);
 			}
 			if (info.label) {
@@ -1341,7 +1603,7 @@ const controlsInsert = (() => {
 			pad.appendChild(button);
 			control.appendChild(pad);
 			if (hideWhenInactive) {
-				control.classList.add(getSel(ElementClass.DISABLED));
+				control.classList.add(EleClass.DISABLED);
 			}
 			if (info.onClick) {
 				button.addEventListener("click", info.onClick);
@@ -1349,16 +1611,17 @@ const controlsInsert = (() => {
 			if (info.setUp) {
 				info.setUp(control);
 			}
-			(document.getElementById(getSel(info.containerId)) as HTMLElement).appendChild(control);
+			(document.getElementById(info.containerId) as HTMLElement).appendChild(control);
 		};
 
 		return (terms: MatchTerms, controlName: ControlButtonName, hideWhenInactive: boolean,
 			controlsInfo: ControlsInfo) => {
 			controlInsertWithInfo(controlName, ({
 				toggleBarCollapsed: {
-					controlClasses: [ ElementClass.UNCOLLAPSIBLE ],
+					controlClasses: [ EleClass.UNCOLLAPSIBLE ],
 					path: "/icons/arrow.svg",
-					containerId: ElementID.BAR_LEFT,
+					pathSecondary: "/icons/mms.svg",
+					containerId: EleID.BAR_LEFT,
 					onClick: () => {
 						controlsInfo.barCollapsed = !controlsInfo.barCollapsed;
 						messageSendBackground({
@@ -1366,27 +1629,27 @@ const controlsInsert = (() => {
 								barCollapsedOn: controlsInfo.barCollapsed,
 							},
 						});
-						const bar = document.getElementById(getSel(ElementID.BAR)) as HTMLElement;
-						bar.classList.toggle(getSel(ElementClass.COLLAPSED), controlsInfo.barCollapsed);
+						const bar = document.getElementById(EleID.BAR) as HTMLElement;
+						bar.classList.toggle(EleClass.COLLAPSED, controlsInfo.barCollapsed);
 					},
 				},
 				disableTabResearch: {
 					path: "/icons/close.svg",
-					containerId: ElementID.BAR_LEFT,	
+					containerId: EleID.BAR_LEFT,	
 					onClick: () => messageSendBackground({
 						deactivateTabResearch: true,
 					}),
 				},
 				performSearch: {
 					path: "/icons/search.svg",
-					containerId: ElementID.BAR_LEFT,
+					containerId: EleID.BAR_LEFT,
 					onClick: () => messageSendBackground({
 						performSearch: true,
 					}),
 				},
 				toggleHighlights: {
 					path: "/icons/show.svg",
-					containerId: ElementID.BAR_LEFT,
+					containerId: EleID.BAR_LEFT,
 					onClick: () => messageSendBackground({
 						toggle: {
 							highlightsShownOn: !controlsInfo.highlightsShown,
@@ -1394,25 +1657,21 @@ const controlsInsert = (() => {
 					}),
 				},
 				appendTerm: {
-					buttonClass: ElementClass.CONTROL_CONTENT,
+					buttonClasses: [ EleClass.CONTROL_BUTTON, EleClass.CONTROL_CONTENT ],
 					path: "/icons/create.svg",
-					containerId: ElementID.BAR_RIGHT,
+					containerId: EleID.BAR_RIGHT,
 					setUp: container => {
-						const pad = container.querySelector(`.${getSel(ElementClass.CONTROL_PAD)}`) as HTMLElement;
+						const pad = container.querySelector(`.${EleClass.CONTROL_PAD}`) as HTMLElement;
 						insertTermInput(terms, pad, TermChange.CREATE, input => pad.appendChild(input));
 						updateTermControlMatchModeClassList(controlsInfo.matchMode, container.classList);
-						const { optionList, controlReveal } = createTermOptionMenu(
-							new MatchTerm("_", controlsInfo.matchMode),
-							terms,
+						const { optionList, controlReveal } = createTermOptionList(
+							undefined,
+							controlsInfo.matchMode,
 							controlsInfo,
-							matchType => {
+							(matchType, checked) => {
 								const matchMode = getTermControlMatchModeFromClassList(container.classList);
-								matchMode[matchType] = !matchMode[matchType];
+								matchMode[matchType] = checked;
 								updateTermControlMatchModeClassList(matchMode, container.classList);
-								// TODO make function
-								container.querySelectorAll(`.${getSel(ElementClass.OPTION)} > input[type="checkbox"]`).forEach((checkbox: HTMLInputElement) =>
-									checkbox.checked = matchMode[getTermOptionMatchType(Array.from(container.classList))]
-								);
 							},
 						);
 						pad.appendChild(controlReveal);
@@ -1421,7 +1680,7 @@ const controlsInsert = (() => {
 				},
 				replaceTerms: {
 					path: "/icons/refresh.svg",
-					containerId: ElementID.BAR_RIGHT,
+					containerId: EleID.BAR_RIGHT,
 					onClick: () => {
 						termsSet(controlsInfo.termsOnHold);
 					},
@@ -1435,21 +1694,10 @@ const controlsInsert = (() => {
 		highlightTags: HighlightTags, hues: TermHues, produceEffectOnCommand: ProduceEffectOnCommand) => {
 		fillStylesheetContent(terms, hues, controlsInfo);
 		const bar = document.createElement("div");
-		bar.id = getSel(ElementID.BAR);
-		bar.addEventListener("dragstart", event => event.preventDefault());
-		const fixVisibility = () => {
-			termControlInputsVisibilityReset();
-			const controlInput = document.activeElement;
-			if (controlInput && controlInput.tagName === "INPUT"
-				&& controlInput.closest(`#${getSel(ElementID.BAR)}`)) {
-				controlInput.classList.add(getSel(ElementClass.OVERRIDE_VISIBILITY));
-			}
-		};
-		bar.addEventListener("mouseenter", fixVisibility);
-		bar.addEventListener("mouseleave", fixVisibility);
+		bar.id = EleID.BAR;
 		// Inputs should not be focusable unless user has already focused bar. (1)
 		const inputsSetFocusable = (focusable: boolean) => {
-			bar.querySelectorAll("input").forEach(input => {
+			bar.querySelectorAll(`input.${EleClass.CONTROL_INPUT}`).forEach((input: HTMLElement) => {
 				if (focusable) {
 					input.removeAttribute("tabindex");
 				} else {
@@ -1457,6 +1705,8 @@ const controlsInsert = (() => {
 				}
 			});
 		};
+		// Attempt to forcibly prevent website code from receiving certain events when the bar has focus.
+		// Works if the website has used event properties; swaps the website-assigned functions with `undefined`.
 		const documentEventProperties: Record<string, ((e: KeyboardEvent) => unknown) | undefined> = {
 			onkeydown: undefined,
 			onkeyup: undefined,
@@ -1478,6 +1728,20 @@ const controlsInsert = (() => {
 				document[property] = documentEventProperties[property];
 			});
 		});
+		const updateInputsFocused = () => {
+			// Causes the last focused input to be forgotten, as long as the user is not currently interacting with the bar.
+			// If the user is interacting with the bar, the information may be needed for restoring (or preparing to restore) focus.
+			if (!document.querySelector(`#${EleID.BAR}:active`)) {
+				bar.querySelectorAll(`.${EleClass.WAS_FOCUSED}`).forEach(input => {
+					input.classList.remove(EleClass.WAS_FOCUSED);
+				});
+			}
+		};
+		bar.addEventListener("mousedown", updateInputsFocused);
+		bar.addEventListener("mouseup", updateInputsFocused);
+		bar.addEventListener("contextmenu", event => {
+			event.preventDefault();
+		});
 		bar.addEventListener("keydown", event => {
 			if (event.key === "Tab") { // This is the only key that will take effect in term inputs; the rest are blocked automatically.
 				event.stopPropagation();
@@ -1485,8 +1749,8 @@ const controlsInsert = (() => {
 				if (!controlInput || !bar.contains(controlInput)) {
 					return;
 				}
-				const control = controlInput.closest(`.${getSel(ElementClass.CONTROL)}`);
-				const barTerms = document.getElementById(getSel(ElementID.BAR_TERMS)) as Element;
+				const control = controlInput.closest(`.${EleClass.CONTROL}`);
+				const barTerms = document.getElementById(EleID.BAR_TERMS) as Element;
 				if (control && !event.shiftKey && control === barTerms.lastElementChild) {
 					// Special case to specifically focus the term append input, in case the button is hidden.
 					event.preventDefault();
@@ -1513,19 +1777,19 @@ const controlsInsert = (() => {
 			}
 		});
 		if (controlsInfo.highlightsShown) {
-			bar.classList.add(getSel(ElementClass.HIGHLIGHTS_SHOWN));
+			bar.classList.add(EleClass.HIGHLIGHTS_SHOWN);
 		}
 		if (!controlsInfo.pageModifyEnabled) {
-			bar.classList.add(getSel(ElementClass.DISABLED));
+			bar.classList.add(EleClass.DISABLED);
 		}
 		const barLeft = document.createElement("span");
-		barLeft.id = getSel(ElementID.BAR_LEFT);
-		barLeft.classList.add(getSel(ElementClass.BAR_CONTROLS));
+		barLeft.id = EleID.BAR_LEFT;
+		barLeft.classList.add(EleClass.BAR_CONTROLS);
 		const barTerms = document.createElement("span");
-		barTerms.id = getSel(ElementID.BAR_TERMS);
+		barTerms.id = EleID.BAR_TERMS;
 		const barRight = document.createElement("span");
-		barRight.id = getSel(ElementID.BAR_RIGHT);
-		barRight.classList.add(getSel(ElementClass.BAR_CONTROLS));
+		barRight.id = EleID.BAR_RIGHT;
+		barRight.classList.add(EleClass.BAR_CONTROLS);
 		bar.appendChild(barLeft);
 		bar.appendChild(barTerms);
 		bar.appendChild(barRight);
@@ -1537,7 +1801,7 @@ const controlsInsert = (() => {
 		terms.forEach((term, i) => insertTermControl(terms, i, termCommands.down[i], termCommands.up[i],
 			controlsInfo, highlightTags));
 		const gutter = document.createElement("div");
-		gutter.id = getSel(ElementID.MARKER_GUTTER);
+		gutter.id = EleID.MARKER_GUTTER;
 		document.body.insertAdjacentElement("afterend", gutter);
 	};
 })();
@@ -1546,8 +1810,8 @@ const controlsInsert = (() => {
  * Removes the control bar and scroll gutter.
  */
 const controlsRemove = () => {
-	const bar = document.getElementById(getSel(ElementID.BAR));
-	const gutter = document.getElementById(getSel(ElementID.MARKER_GUTTER));
+	const bar = document.getElementById(EleID.BAR);
+	const gutter = document.getElementById(EleID.MARKER_GUTTER);
 	if (bar) {
 		if (document.activeElement && bar.contains(document.activeElement)) {
 			(document.activeElement as HTMLElement).blur(); // Allow focus+selection to be properly restored.
@@ -1558,18 +1822,6 @@ const controlsRemove = () => {
 		gutter.remove();
 	}
 };
-
-/**
- * Removes the visibility classes of all term control inputs, resetting their visibility.
- */
-const termControlInputsVisibilityReset = () =>
-	elementsPurgeClass(
-		getSel(ElementClass.OVERRIDE_VISIBILITY),
-		document.getElementById(getSel(ElementID.BAR)) as HTMLElement,
-		"input",
-		classList => !classList.contains(getSel(ElementClass.OVERRIDE_FOCUS)),
-	)
-;
 
 /*
 HIGHLIGHTING - UTILITY
@@ -1637,22 +1889,20 @@ const insertScrollMarkersPaint = (terms: MatchTerms, hues: TermHues) => {
 		return; // Efficient escape in case of no possible markers to be inserted.
 	}
 	// Markers are indistinct after the hue limit, and introduce unacceptable lag by ~10 terms.
-	const termSelectorsAllowed = new Set(terms.slice(0, hues.length).map(term => term.selector));
-	const gutter = document.getElementById(getSel(ElementID.MARKER_GUTTER)) as HTMLElement;
+	const termsAllowed = new Set(terms.slice(0, hues.length));
+	const gutter = document.getElementById(EleID.MARKER_GUTTER) as HTMLElement;
 	let markersHtml = "";
 	document.body.querySelectorAll(
 		"[markmysearch-h_id]" + ((paintUseExperimental && !paintUsePaintingFallback) ? ", [markmysearch-h_beneath]" : "")
 	).forEach((element: HTMLElement) => {
-		const termSelectors: Set<string> = new Set((element[ElementProperty.INFO] as ElementInfo | undefined)?.flows
-			.flatMap(flow => flow.boxesInfo
-				.map(boxInfo => boxInfo.term.selector)
-				.filter(termSelector => termSelectorsAllowed.has(termSelector))
-			)
-		);
+		const terms = (element[EleProperty.INFO] as ElementInfo | undefined)?.flows.flatMap(flow => flow.boxesInfo
+			.map(boxInfo => boxInfo.term)
+			.filter(term => termsAllowed.has(term))
+		) ?? [];
 		const yRelative = getElementYRelative(element);
 		// TODO use single marker with custom style
-		markersHtml += Array.from(termSelectors).map((termSelector, i) => `<div class="${
-			getSel(ElementClass.TERM, termSelector)
+		markersHtml += terms.map((term, i) => `<div class="${
+			getTermClass(term.token)
 		}" top="${yRelative}" style="top: ${yRelative * 100}%; padding-left: ${i * 5}px; z-index: ${i * -1}"></div>`);
 	});
 	gutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
@@ -1665,8 +1915,8 @@ Methods for calculating and interpreting highlighting caches, as well as managin
 */
 
 const cacheExtend = (element: Element, highlightTags: HighlightTags, cacheModify = (element: Element) => {
-	if (!element[ElementProperty.INFO]) {
-		element[ElementProperty.INFO] = {
+	if (!element[EleProperty.INFO]) {
+		element[EleProperty.INFO] = {
 			id: "",
 			styleRuleIdx: -1,
 			isPaintable: (paintUseExperimental && !paintUsePaintingFallback) ? !element.closest("a") : true,
@@ -1758,8 +2008,8 @@ const flowsRemove = (element: Element, highlightTags: HighlightTags) => {
 	if (highlightTags.reject.has(element.tagName)) {
 		return;
 	}
-	if (element[ElementProperty.INFO]) {
-		(element[ElementProperty.INFO] as ElementInfo).flows = [];
+	if (element[EleProperty.INFO]) {
+		(element[EleProperty.INFO] as ElementInfo).flows = [];
 	}
 	Array.from(element.children).forEach(child => flowsRemove(child, highlightTags));
 };
@@ -1780,8 +2030,8 @@ const flowCacheWithBoxesInfo = (terms: MatchTerms, textFlow: Array<Text>,
 	const getAncestorCommon = (ancestor: Element, node: Node): Element =>
 		ancestor.contains(node) ? ancestor : getAncestorCommon(ancestor.parentElement as Element, node);
 	const ancestor = getAncestorCommon(flow.nodeStart.parentElement as Element, flow.nodeEnd);
-	if (ancestor[ElementProperty.INFO]) {
-		(ancestor[ElementProperty.INFO] as ElementInfo).flows.push(flow);
+	if (ancestor[EleProperty.INFO]) {
+		(ancestor[EleProperty.INFO] as ElementInfo).flows.push(flow);
 	} else {
 		// This condition should be impossible, but since in rare cases (typically when running before "document_idle")
 		// mutation observers may not always fire, it must be accounted for.
@@ -1830,8 +2080,8 @@ const flowCacheWithBoxesInfo = (terms: MatchTerms, textFlow: Array<Text>,
 	if (flow.boxesInfo.length) {
 		const ancestorHighlightable = getAncestorHighlightable(ancestor.firstChild as Node);
 		styleUpdates.observe(ancestorHighlightable);
-		if ((ancestorHighlightable[ElementProperty.INFO] as ElementInfo).id === "") {
-			const highlighting = ancestorHighlightable[ElementProperty.INFO] as ElementInfo;
+		if ((ancestorHighlightable[EleProperty.INFO] as ElementInfo).id === "") {
+			const highlighting = ancestorHighlightable[EleProperty.INFO] as ElementInfo;
 			highlighting.id = getHighlightingId.next().value;
 			ancestorHighlightable.setAttribute("markmysearch-h_id", highlighting.id);
 			ancestorHighlightable["markmysearch-h_id"] = highlighting.id;
@@ -1922,12 +2172,12 @@ const boxesInfoCalculateForFlowOwnersFromContent = (terms: MatchTerms, element: 
 const boxesInfoRemoveForTerms = (terms: MatchTerms = [], root: HTMLElement | DocumentFragment = document.body) => {
 	for (const element of Array.from(root.querySelectorAll("[markmysearch-h_id]"))) {
 		const filterBoxesInfo = (element: Element) => {
-			const elementInfo = element[ElementProperty.INFO] as ElementInfo;
+			const elementInfo = element[EleProperty.INFO] as ElementInfo;
 			if (!elementInfo) {
 				return;
 			}
 			elementInfo.flows.forEach(flow => {
-				flow.boxesInfo = flow.boxesInfo.filter(boxInfo => terms.every(term => term.selector !== boxInfo.term.selector));
+				flow.boxesInfo = flow.boxesInfo.filter(boxInfo => terms.every(term => term.token !== boxInfo.term.token));
 			});
 			Array.from(element.children).forEach(child => filterBoxesInfo(child));
 		};
@@ -1946,7 +2196,7 @@ paintUseExperimental
 	? paintUsePaintingFallback
 		? highlightId =>
 			`body [markmysearch-h_id="${highlightId}"] { background-image: -moz-element(#${
-				getSel(ElementID.DRAW_ELEMENT, highlightId)
+				getElementDrawId(highlightId)
 			}) !important; background-repeat: no-repeat !important; }`
 		: (highlightId, boxes) =>
 			`body [markmysearch-h_id="${highlightId}"] { --markmysearch-boxes: ${
@@ -1954,15 +2204,15 @@ paintUseExperimental
 			}; }`
 	: (highlightId, boxes, terms) =>
 		`#${
-			getSel(ElementID.BAR)
+			EleID.BAR
 		}.${
-			getSel(ElementClass.HIGHLIGHTS_SHOWN)
+			EleClass.HIGHLIGHTS_SHOWN
 		} ~ body [markmysearch-h_id="${
 			highlightId
 		}"] { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E${
 			boxes.map(box =>
 				`%3Crect width='${box.width}' height='${box.height}' x='${box.x}' y='${box.y}' fill='hsl(${(
-					terms.find(term => term.selector === box.selector) as MatchTerm).hue
+					terms.find(term => term.token === box.token) as MatchTerm).hue
 				} 100% 50% / 0.4)'/%3E`
 			).join("")
 		}%3C/svg%3E") !important; }`
@@ -1970,7 +2220,7 @@ paintUseExperimental
 
 const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Array<HighlightStyleRuleInfo> = (() => {
 	const calculateBoxes = (owner: Element, element: Element, range: Range): Array<HighlightBox> => {
-		const elementInfo = element[ElementProperty.INFO] as ElementInfo;
+		const elementInfo = element[EleProperty.INFO] as ElementInfo;
 		if (!elementInfo || elementInfo.flows.every(flow => flow.boxesInfo.length === 0)) {
 			return [];
 		}
@@ -2003,7 +2253,7 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 						}
 					}
 					boxInfo.boxes.push({
-						selector: boxInfo.term.selector,
+						token: boxInfo.term.token,
 						x: Math.round(x),
 						y: Math.round(y),
 						width: Math.round(textRect.width),
@@ -2017,14 +2267,14 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 
 	const getBoxesOwned = (owner: Element, element: Element, range: Range): Array<HighlightBox> =>
 		calculateBoxes(owner, element, range).concat(Array.from(element.children).flatMap(child =>
-			(child[ElementProperty.INFO] ? !(child[ElementProperty.INFO] as ElementInfo).isPaintable : false)
+			(child[EleProperty.INFO] ? !(child[EleProperty.INFO] as ElementInfo).isPaintable : false)
 				? getBoxesOwned(owner, child, range) : []
 		))
 	;
 
 	const collectStyleRules = (element: Element, recurse: boolean,
 		range: Range, styleRules: Array<HighlightStyleRuleInfo>, terms: MatchTerms) => {
-		const elementInfo = element[ElementProperty.INFO] as ElementInfo;
+		const elementInfo = element[EleProperty.INFO] as ElementInfo;
 		const boxes: Array<HighlightBox> = getBoxesOwned(element, element, range);
 		if (boxes.length) {
 			styleRules.push({
@@ -2033,18 +2283,18 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 			});
 		}
 		(recurse ? Array.from(element.children) as Array<HTMLElement> : []).forEach(child => {
-			if (child[ElementProperty.INFO]) {
+			if (child[EleProperty.INFO]) {
 				collectStyleRules(child, recurse, range, styleRules, terms);
 			}
 		});
 	};
 
 	const collectElements = (element: Element, recurse: boolean, range: Range, containers: Array<Element>) => {
-		const elementInfo = element[ElementProperty.INFO] as ElementInfo;
+		const elementInfo = element[EleProperty.INFO] as ElementInfo;
 		const boxes: Array<HighlightBox> = getBoxesOwned(element, element, range);
 		if (boxes.length) {
 			const container = document.createElement("div");
-			container.id = getSel(ElementID.DRAW_ELEMENT, elementInfo.id);
+			container.id = getElementDrawId(elementInfo.id);
 			boxes.forEach(box => {
 				const element = document.createElement("div");
 				element.style.position = "absolute";
@@ -2052,17 +2302,21 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 				element.style.top = box.y.toString() + "px";
 				element.style.width = box.width.toString() + "px";
 				element.style.height = box.height.toString() + "px";
-				element.classList.add(getSel(ElementClass.TERM), getSel(ElementClass.TERM, box.selector));
+				element.classList.add(EleClass.TERM, getTermClass(box.token));
 				container.appendChild(element);
 			});
-			const boxRightmost = boxes.reduce((box, boxCurrent) => box && (box.x + box.width > boxCurrent.x + boxCurrent.width) ? box : boxCurrent);
-			const boxDownmost = boxes.reduce((box, boxCurrent) => box && (box.y + box.height > boxCurrent.y + boxCurrent.height) ? box : boxCurrent);
+			const boxRightmost = boxes.reduce((box, boxCurrent) =>
+				box && (box.x + box.width > boxCurrent.x + boxCurrent.width) ? box : boxCurrent
+			);
+			const boxDownmost = boxes.reduce((box, boxCurrent) =>
+				box && (box.y + box.height > boxCurrent.y + boxCurrent.height) ? box : boxCurrent
+			);
 			container.style.width = (boxRightmost.x + boxRightmost.width).toString() + "px";
 			container.style.height = (boxDownmost.y + boxDownmost.height).toString() + "px";
 			containers.push(container);
 		}
 		(recurse ? Array.from(element.children) as Array<HTMLElement> : []).forEach(child => {
-			if (child[ElementProperty.INFO]) {
+			if (child[EleProperty.INFO]) {
 				collectElements(child, recurse, range, containers);
 			}
 		});
@@ -2072,7 +2326,7 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 		? (root, recurse, terms) => {
 			const containers: Array<Element> = [];
 			collectElements(root, recurse, document.createRange(), containers);
-			const parent = document.getElementById(getSel(ElementID.DRAW_CONTAINER)) as Element;
+			const parent = document.getElementById(EleID.DRAW_CONTAINER) as Element;
 			containers.forEach(container => {
 				const containerExisting = document.getElementById(container.id);
 				if (containerExisting) {
@@ -2094,10 +2348,10 @@ const getStyleRules: (root: Element, recurse: boolean, terms: MatchTerms) => Arr
 })();
 
 const styleUpdate = (styleRules: Array<HighlightStyleRuleInfo>) => {
-	const styleSheet = (document.getElementById(getSel(ElementID.STYLE_PAINT)) as HTMLStyleElement)
+	const styleSheet = (document.getElementById(EleID.STYLE_PAINT) as HTMLStyleElement)
 		.sheet as CSSStyleSheet;
 	styleRules.forEach(({ rule, element }) => {
-		const elementInfo = element[ElementProperty.INFO] as ElementInfo;
+		const elementInfo = element[EleProperty.INFO] as ElementInfo;
 		if (elementInfo.styleRuleIdx === -1) {
 			elementInfo.styleRuleIdx = styleSheet.cssRules.length;
 		} else {
@@ -2137,14 +2391,25 @@ class UnbrokenNodeList {
 		}
 	}
 
-	insertAfter (itemBefore: UnbrokenNodeListItem | null, value: Text | null) {
-		if (value) {
-			if (itemBefore) {
-				itemBefore.next = { next: itemBefore.next, value };
-			} else {
-				this.first = { next: this.first, value };
-			}
+	insertAfter (itemBefore: UnbrokenNodeListItem | null, value: Text): UnbrokenNodeListItem {
+		if (itemBefore) {
+			itemBefore.next = { next: itemBefore.next, value };
+			return itemBefore.next;
+		} else {
+			this.first = { next: this.first, value };
+			return this.first;
 		}
+	}
+
+	remove (itemBefore: UnbrokenNodeListItem | null) {
+		if (!itemBefore) {
+			this.first = this.first?.next ?? null;
+			return;
+		}
+		if (this.last === itemBefore.next) {
+			this.last = itemBefore;
+		}
+		itemBefore.next = itemBefore.next?.next ?? null;
 	}
 
 	getText () {
@@ -2182,33 +2447,42 @@ const generateTermHighlightsUnderNode = (() => {
 	/**
 	 * Highlights a term matched in a text node.
 	 * @param term The term matched.
-	 * @param textEndNode The text node to highlight inside.
+	 * @param textAfterNode The text node to highlight inside.
 	 * @param start The first character index of the match within the text node.
 	 * @param end The last character index of the match within the text node.
 	 * @param nodeItems The singly linked list of consecutive text nodes being internally highlighted.
 	 * @param nodeItemPrevious The previous item in the text node list.
 	 * @returns The new previous item (the item just highlighted).
 	 */
-	const highlightInsideNode = (term: MatchTerm, textEndNode: Node, start: number, end: number,
-		nodeItems: UnbrokenNodeList, nodeItemPrevious: UnbrokenNodeListItem | null): UnbrokenNodeListItem => {
+	const highlightInsideNode = (
+		term: MatchTerm,
+		textAfterNode: Node,
+		start: number,
+		end: number,
+		nodeItems: UnbrokenNodeList,
+		nodeItemPrevious: UnbrokenNodeListItem | null,
+	): UnbrokenNodeListItem => {
 		// This is necessarily a destructive strategy. Occasional damage to the webpage and its functionality is unavoidable.
-		const text = textEndNode.textContent as string;
-		const textStart = text.substring(0, start);
-		const highlight = document.createElement("mms-h");
-		highlight.classList.add(getSel(ElementClass.TERM, term.selector));
-		highlight.textContent = text.substring(start, end);
-		textEndNode.textContent = text.substring(end);
-		(textEndNode.parentNode as Node).insertBefore(highlight, textEndNode);
-		(highlight.parentNode as Node)["markmysearchKnown"] = true;
-		nodeItems.insertAfter(nodeItemPrevious, highlight.firstChild as Text);
-		if (textStart !== "") {
-			const textStartNode = document.createTextNode(textStart);
-			(highlight.parentNode as Node).insertBefore(textStartNode, highlight);
-			nodeItems.insertAfter(nodeItemPrevious, textStartNode);
-			return ((nodeItemPrevious ? nodeItemPrevious.next : nodeItems.first) as UnbrokenNodeListItem)
-				.next as UnbrokenNodeListItem;
+		const text = textAfterNode.textContent ?? "";
+		if (text.length === 0) {
+			textAfterNode.parentElement?.removeChild(textAfterNode);
+			return (nodeItemPrevious ? nodeItemPrevious.next : nodeItems.first) as UnbrokenNodeListItem;
 		}
-		return (nodeItemPrevious ? nodeItemPrevious.next : nodeItems.first) as UnbrokenNodeListItem;
+		const parent = textAfterNode.parentNode as Node;
+		const textEndNode = document.createTextNode(text.substring(start, end));
+		const highlight = document.createElement(HIGHLIGHT_TAG);
+		highlight.classList.add(getTermClass(term.token));
+		highlight.appendChild(textEndNode);
+		textAfterNode.textContent = text.substring(end);
+		parent.insertBefore(highlight, textAfterNode);
+		parent[ELEMENT_IS_KNOWN] = true;
+		const textEndNodeItem = nodeItems.insertAfter(nodeItemPrevious, textEndNode);
+		if (start > 0) {
+			const textStartNode = document.createTextNode(text.substring(0, start));
+			parent.insertBefore(textStartNode, highlight);
+			nodeItems.insertAfter(nodeItemPrevious, textStartNode);
+		}
+		return textEndNodeItem;
 	};
 
 	/**
@@ -2235,6 +2509,9 @@ const generateTermHighlightsUnderNode = (() => {
 				}
 				// eslint-disable-next-line no-constant-condition
 				while (true) {
+					// TODO join together nodes where possible
+					// TODO investigate why, under some circumstances, new empty highlight elements keep being produced
+					// - (to observe, remove the code that deletes empty nodes during restoration)
 					nodeItemPrevious = highlightInsideNode(
 						term,
 						nodeItem.value,
@@ -2265,8 +2542,13 @@ const generateTermHighlightsUnderNode = (() => {
 	 * @param nodeItems A singly linked list of consecutive text nodes to highlight inside.
 	 * @param visitSiblings Whether to visit the siblings of the root node.
 	 */
-	const insertHighlights = (terms: MatchTerms, node: Node, highlightTags: HighlightTags,
-		nodeItems = new UnbrokenNodeList, visitSiblings = true) => {
+	const insertHighlights = (
+		terms: MatchTerms,
+		node: Node,
+		highlightTags: HighlightTags,
+		nodeItems = new UnbrokenNodeList,
+		visitSiblings = true,
+	) => {
 		// TODO support for <iframe>?
 		do {
 			switch (node.nodeType) {
@@ -2296,8 +2578,12 @@ const generateTermHighlightsUnderNode = (() => {
 		} while (node && visitSiblings);
 	};
 
-	return (terms: MatchTerms, rootNode: Node,
-		highlightTags: HighlightTags, termCountCheck: TermCountCheck) => {
+	return (
+		terms: MatchTerms,
+		rootNode: Node,
+		highlightTags: HighlightTags,
+		termCountCheck: TermCountCheck,
+	) => {
 		if (rootNode.nodeType === Node.TEXT_NODE) {
 			const nodeItems = new UnbrokenNodeList;
 			nodeItems.push(rootNode as Text);
@@ -2320,8 +2606,10 @@ const generateTermHighlightsUnderNode = (() => {
  * @param root A root node under which to remove highlights.
  */
 const elementsRestore = (classNames: Array<string> = [], root: HTMLElement | DocumentFragment = document.body) => {
-	const highlights = Array.from(root.querySelectorAll(classNames.length ? `mms-h.${classNames.join(", mms-h.")}` : "mms-h"))
-		.reverse();
+	const highlights = Array.from(root.querySelectorAll(
+		classNames.length ? `${HIGHLIGHT_TAG}.${classNames.join(`, ${HIGHLIGHT_TAG}.`)}` : HIGHLIGHT_TAG
+	)).reverse();
+	// TODO attempt to join text nodes back together
 	for (const highlight of Array.from(highlights)) {
 		highlight.outerHTML = highlight.innerHTML;
 	}
@@ -2331,8 +2619,8 @@ const elementsRestore = (classNames: Array<string> = [], root: HTMLElement | Doc
 			return;
 		}
 	}
-	elementsPurgeClass(getSel(ElementClass.FOCUS_CONTAINER), root);
-	elementsPurgeClass(getSel(ElementClass.FOCUS), root);
+	elementsPurgeClass(EleClass.FOCUS_CONTAINER, root);
+	elementsPurgeClass(EleClass.FOCUS, root);
 	elementsRemakeUnfocusable(root);
 };
 
@@ -2342,75 +2630,64 @@ const elementsRestore = (classNames: Array<string> = [], root: HTMLElement | Doc
  * @param highlightTags Element tags which are rejected from highlighting OR allow flows of text nodes to leave.
  * @param hues Color hues for term styles to cycle through.
  */
-const insertScrollMarkersClassic = (() => {
-	/**
-	 * Extracts the selector of a term from its prefixed class name form.
-	 * @param highlightClassName The single class name of a term highlight.
-	 * @returns The corresponding term selector.
-	 */
-	const getTermSelector = (highlightClassName: string) =>
-		highlightClassName.slice(getSel(ElementClass.TERM).length + 1)
-	;
-
-	return (terms: MatchTerms, highlightTags: HighlightTags, hues: TermHues) => {
-		if (terms.length === 0) {
-			return; // No terms results in an empty selector, which is not allowed.
-		}
-		const regexMatchTermSelector = new RegExp(`\\b${getSel(ElementClass.TERM)}(?:-\\w+)+\\b`);
-		const containerBlockSelector = getContainerBlockSelector(highlightTags);
-		const gutter = document.getElementById(getSel(ElementID.MARKER_GUTTER)) as HTMLElement;
-		const containersInfo: Array<{
-			container: HTMLElement
-			termsAdded: Set<string>
-		}> = [];
-		let markersHtml = "";
-		document.body.querySelectorAll(terms
-			.slice(0, hues.length) // The scroll markers are indistinct after the hue limit, and introduce unacceptable lag by ~10 terms
-			.map(term => `mms-h.${getSel(ElementClass.TERM, term.selector)}`)
-			.join(", ")
-		).forEach((highlight: HTMLElement) => {
-			const container = getContainerBlock(highlight, highlightTags, containerBlockSelector);
-			const containerIdx = containersInfo.findIndex(containerInfo => container.contains(containerInfo.container));
-			const className = (highlight.className.match(regexMatchTermSelector) as RegExpMatchArray)[0];
-			const yRelative = getElementYRelative(container);
-			let markerCss = `top: ${yRelative * 100}%;`;
-			if (containerIdx !== -1) {
-				if (containersInfo[containerIdx].container === container) {
-					if (containersInfo[containerIdx].termsAdded.has(getTermSelector(className))) {
-						return;
-					} else {
-						const termsAddedCount = Array.from(containersInfo[containerIdx].termsAdded).length;
-						markerCss += `padding-left: ${termsAddedCount * 5}px; z-index: ${termsAddedCount * -1}`;
-						containersInfo[containerIdx].termsAdded.add(getTermSelector(className));
-					}
+const insertScrollMarkersClassic = (terms: MatchTerms, highlightTags: HighlightTags, hues: TermHues) => {
+	if (terms.length === 0) {
+		return; // No terms results in an empty selector, which is not allowed.
+	}
+	const regexMatchTermSelector = new RegExp(`\\b${EleClass.TERM}(?:-\\w+)+\\b`);
+	const containerBlockSelector = getContainerBlockSelector(highlightTags);
+	const gutter = document.getElementById(EleID.MARKER_GUTTER) as HTMLElement;
+	const containersInfo: Array<{
+		container: HTMLElement
+		termsAdded: Set<string>
+	}> = [];
+	let markersHtml = "";
+	document.body.querySelectorAll(terms
+		.slice(0, hues.length) // The scroll markers are indistinct after the hue limit, and introduce unacceptable lag by ~10 terms
+		.map(term => `${HIGHLIGHT_TAG}.${getTermClass(term.token)}`)
+		.join(", ")
+	).forEach((highlight: HTMLElement) => {
+		const container = getContainerBlock(highlight, highlightTags, containerBlockSelector);
+		const containerIdx = containersInfo.findIndex(containerInfo => container.contains(containerInfo.container));
+		const className = (highlight.className.match(regexMatchTermSelector) as RegExpMatchArray)[0];
+		const yRelative = getElementYRelative(container);
+		let markerCss = `top: ${yRelative * 100}%;`;
+		if (containerIdx !== -1) {
+			if (containersInfo[containerIdx].container === container) {
+				if (containersInfo[containerIdx].termsAdded.has(getTermToken(className))) {
+					return;
 				} else {
-					containersInfo.splice(containerIdx);
-					containersInfo.push({ container, termsAdded: new Set([ getTermSelector(className) ]) });
+					const termsAddedCount = Array.from(containersInfo[containerIdx].termsAdded).length;
+					markerCss += `padding-left: ${termsAddedCount * 5}px; z-index: ${termsAddedCount * -1}`;
+					containersInfo[containerIdx].termsAdded.add(getTermToken(className));
 				}
 			} else {
-				containersInfo.push({ container, termsAdded: new Set([ getTermSelector(className) ]) });
+				containersInfo.splice(containerIdx);
+				containersInfo.push({ container, termsAdded: new Set([ getTermToken(className) ]) });
 			}
-			markersHtml += `<div class="${className}" top="${yRelative}" style="${markerCss}"></div>`;
-		});
-		gutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
-		gutter.innerHTML = markersHtml;
-	};
-})();
+		} else {
+			containersInfo.push({ container, termsAdded: new Set([ getTermToken(className) ]) });
+		}
+		markersHtml += `<div class="${className}" top="${yRelative}" style="${markerCss}"></div>`;
+	});
+	gutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
+	gutter.innerHTML = markersHtml;
+};
 
 // TODO document
 const focusOnScrollMarkerClassic = (term: MatchTerm | undefined, container: HTMLElement) => {
-	const scrollMarkerGutter = document.getElementById(getSel(ElementID.MARKER_GUTTER)) as HTMLElement;
-	elementsPurgeClass(getSel(ElementClass.FOCUS), scrollMarkerGutter);
+	const scrollMarkerGutter = document.getElementById(EleID.MARKER_GUTTER) as HTMLElement;
+	elementsPurgeClass(EleClass.FOCUS, scrollMarkerGutter);
 	// eslint-disable-next-line no-constant-condition
 	[6, 5, 4, 3, 2].some(precisionFactor => {
 		const precision = 10**precisionFactor;
 		const scrollMarker = scrollMarkerGutter.querySelector(
-			`${term ? `.${getSel(ElementClass.TERM, term.selector)}` : ""}[top^="${
+			`${term ? `.${getTermClass(term.token)}` : ""}[top^="${
 				Math.trunc(getElementYRelative(container) * precision) / precision
 			}"]`
 		) as HTMLElement | null;
 		if (scrollMarker) {
-			scrollMarker.classList.add(getSel(ElementClass.FOCUS));
+			scrollMarker.classList.add(EleClass.FOCUS);
 			return true;
 		}
 		return false;
@@ -2463,21 +2740,21 @@ const focusOnTermJumpClassic = (() => {
 			}
 		}
 		const container = getContainerBlock(elementTerm.parentElement as HTMLElement, highlightTags);
-		container.classList.add(getSel(ElementClass.FOCUS_CONTAINER));
-		elementTerm.classList.add(getSel(ElementClass.FOCUS));
-		elementToSelect = Array.from(container.getElementsByTagName("mms-h"))
+		container.classList.add(EleClass.FOCUS_CONTAINER);
+		elementTerm.classList.add(EleClass.FOCUS);
+		elementToSelect = Array.from(container.getElementsByTagName(HIGHLIGHT_TAG))
 			.every(thisElement => getContainerBlock(thisElement.parentElement as HTMLElement, highlightTags) === container)
 			? container
 			: elementTerm;
 		if (elementToSelect.tabIndex === -1) {
-			elementToSelect.classList.add(getSel(ElementClass.FOCUS_REVERT));
+			elementToSelect.classList.add(EleClass.FOCUS_REVERT);
 			elementToSelect.tabIndex = 0;
 		}
 		focusElement(elementToSelect);
 		if (document.activeElement !== elementToSelect) {
 			const element = document.createElement("div");
 			element.tabIndex = 0;
-			element.classList.add(getSel(ElementClass.REMOVE));
+			element.classList.add(EleClass.REMOVE);
 			elementToSelect.insertAdjacentElement(reverse ? "afterbegin" : "beforeend", element);
 			elementToSelect = element;
 			focusElement(elementToSelect);
@@ -2489,14 +2766,14 @@ const focusOnTermJumpClassic = (() => {
 	};
 
 	return (controlsInfo: ControlsInfo, highlightTags: HighlightTags, reverse: boolean, term?: MatchTerm) => {
-		const termSelector = term ? getSel(ElementClass.TERM, term.selector) : "";
+		const termSelector = term ? getTermClass(term.token) : undefined;
 		const focusBase = document.body
-			.getElementsByClassName(getSel(ElementClass.FOCUS))[0] as HTMLElement;
+			.getElementsByClassName(EleClass.FOCUS)[0] as HTMLElement;
 		const focusContainer = document.body
-			.getElementsByClassName(getSel(ElementClass.FOCUS_CONTAINER))[0] as HTMLElement;
+			.getElementsByClassName(EleClass.FOCUS_CONTAINER)[0] as HTMLElement;
 		const selection = document.getSelection();
 		const activeElement = document.activeElement;
-		if (activeElement && activeElement.tagName === "INPUT" && activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+		if (activeElement && activeElement.tagName === "INPUT" && activeElement.closest(`#${EleID.BAR}`)) {
 			(activeElement as HTMLInputElement).blur();
 		}
 		const selectionFocus = selection && (!activeElement
@@ -2506,8 +2783,8 @@ const focusOnTermJumpClassic = (() => {
 			? selection.focusNode
 			: activeElement ?? document.body;
 		if (focusBase) {
-			focusBase.classList.remove(getSel(ElementClass.FOCUS));
-			elementsPurgeClass(getSel(ElementClass.FOCUS_CONTAINER));
+			focusBase.classList.remove(EleClass.FOCUS);
+			elementsPurgeClass(EleClass.FOCUS_CONTAINER);
 			elementsRemakeUnfocusable();
 		}
 		const selectionFocusContainer = selectionFocus
@@ -2519,7 +2796,7 @@ const focusOnTermJumpClassic = (() => {
 			: undefined;
 		const walkSelectionFocusContainer = { accept: false };
 		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement) =>
-			element.tagName === "MMS-H"
+			element.tagName === HIGHLIGHT_TAG_UPPER
 			&& (termSelector ? element.classList.contains(termSelector) : true)
 			&& isVisible(element)
 			&& (getContainerBlock(element, highlightTags) !== selectionFocusContainer || walkSelectionFocusContainer.accept)
@@ -2534,7 +2811,7 @@ const focusOnTermJumpClassic = (() => {
 		if (selection) {
 			selection.setBaseAndExtent(elementSelected, 0, elementSelected, 0);
 		}
-		document.body.querySelectorAll(`.${getSel(ElementClass.REMOVE)}`).forEach((element: HTMLElement) => {
+		document.body.querySelectorAll(`.${EleClass.REMOVE}`).forEach((element: HTMLElement) => {
 			element.remove();
 		});
 		focusOnScrollMarker(term, container, controlsInfo);
@@ -2553,7 +2830,7 @@ const focusOnTermStepClassic = (() => {
 		nextSiblingMethod: "nextSibling" | "previousSibling"): HTMLElement =>
 		node[nextSiblingMethod]
 			? (node[nextSiblingMethod] as Node).nodeType === Node.ELEMENT_NODE
-				? (node[nextSiblingMethod] as HTMLElement).tagName === "MMS-H"
+				? (node[nextSiblingMethod] as HTMLElement).tagName === HIGHLIGHT_TAG_UPPER
 					? getSiblingHighlightFinal(node[nextSiblingMethod] as HTMLElement, node[nextSiblingMethod] as HTMLElement,
 						nextSiblingMethod)
 					: highlight
@@ -2565,11 +2842,10 @@ const focusOnTermStepClassic = (() => {
 			: highlight
 	;
 
-	const getTopLevelHighlight = (element: HTMLElement) =>
-		(element.parentElement as HTMLElement).closest("mms-h")
-			? getTopLevelHighlight((element.parentElement as HTMLElement).closest("mms-h") as HTMLElement)
-			: element
-	;
+	const getTopLevelHighlight = (element: Element) => {
+		const closestHighlight = (element.parentElement as Element).closest(HIGHLIGHT_TAG);
+		return closestHighlight ? getTopLevelHighlight(closestHighlight) : element;
+	};
 
 	const stepToElement = (controlsInfo: ControlsInfo, highlightTags: HighlightTags, element: HTMLElement) => {
 		element = getTopLevelHighlight(element);
@@ -2581,10 +2857,10 @@ const focusOnTermStepClassic = (() => {
 	};
 
 	return (controlsInfo: ControlsInfo, highlightTags: HighlightTags, reversed: boolean, nodeStart?: Node) => {
-		elementsPurgeClass(getSel(ElementClass.FOCUS_CONTAINER));
-		elementsPurgeClass(getSel(ElementClass.FOCUS));
+		elementsPurgeClass(EleClass.FOCUS_CONTAINER);
+		elementsPurgeClass(EleClass.FOCUS);
 		const selection = getSelection();
-		const bar = document.getElementById(getSel(ElementID.BAR));
+		const bar = document.getElementById(EleID.BAR);
 		if (!selection || !bar) {
 			return;
 		}
@@ -2605,9 +2881,11 @@ const focusOnTermStepClassic = (() => {
 			(document.activeElement as HTMLElement).blur();
 		}
 		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement) =>
-			(element.parentElement as Element).closest("mms-h")
+			(element.parentElement as Element).closest(HIGHLIGHT_TAG)
 				? NodeFilter.FILTER_REJECT
-				: (element.tagName === "MMS-H" && isVisible(element)) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+				: (element.tagName === HIGHLIGHT_TAG_UPPER && isVisible(element))
+					? NodeFilter.FILTER_ACCEPT
+					: NodeFilter.FILTER_SKIP
 		);
 		walker.currentNode = nodeCurrent;
 		const element = walker[reversed ? "previousNode" : "nextNode"]() as HTMLElement | null;
@@ -2641,7 +2919,7 @@ const beginHighlighting = (
 ) => {
 	mutationUpdates.disconnect();
 	if (termsToPurge.length) {
-		elementsRestore(termsToPurge.map(term => getSel(ElementClass.TERM, term.selector)));
+		elementsRestore(termsToPurge.map(term => getTermClass(term.token)));
 	}
 	generateTermHighlightsUnderNode(terms, document.body, highlightTags, termCountCheck);
 	terms.forEach(term => updateTermOccurringStatus(term, controlsInfo));
@@ -2654,7 +2932,7 @@ const beginHighlighting = (
  */
 const focusReturnToDocument = (): boolean => {
 	const activeElement = document.activeElement;
-	if (activeElement && activeElement.tagName === "INPUT" && activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+	if (activeElement && activeElement.tagName === "INPUT" && activeElement.closest(`#${EleID.BAR}`)) {
 		(activeElement as HTMLInputElement).blur();
 		return true;
 	}
@@ -2678,7 +2956,7 @@ const mutationUpdatesGet = (() => {
 	 * @returns `true` if determined highlightable, `false` otherwise.
 	 */
 	const canHighlightElement = (rejectSelector: string, element: Element): boolean =>
-		!element.closest(rejectSelector) && element.tagName !== "MMS-H"
+		!element.closest(rejectSelector) && element.tagName !== HIGHLIGHT_TAG_UPPER
 	;
 
 	return (
@@ -2739,16 +3017,16 @@ const mutationUpdatesGet = (() => {
 						? mutation.target.parentElement as HTMLElement
 						: mutation.target as HTMLElement;
 					if (element) {
-						if (element["markmysearchKnown"]) {
+						if (element[ELEMENT_IS_KNOWN]) {
 							elementsKnown.add(element);
-						} else if ((mutation.type === "childList" || !element.querySelector("mms-h"))
+						} else if ((mutation.type === "childList" || !element.querySelector(HIGHLIGHT_TAG))
 							&& canHighlightElement(rejectSelector, element)) {
 							elements.add(element);
 						}
 					}
 				}
 				for (const element of elementsKnown) {
-					delete element["markmysearchKnown"];
+					delete element[ELEMENT_IS_KNOWN];
 				}
 				if (elementsKnown.size) {
 					//mutationUpdates.observe();
@@ -2814,15 +3092,15 @@ const styleUpdatesGet = (elementsVisible: Set<Element>, terms: MatchTerms): Styl
 		entries.forEach(entry => {
 			if (entry.isIntersecting) {
 				//console.log(entry.target, "intersecting");
-				if (entry.target[ElementProperty.INFO]) {
+				if (entry.target[EleProperty.INFO]) {
 					elementsVisible.add(entry.target);
 					shiftObserver.observe(entry.target);
 					styleRules = styleRules.concat(getStyleRules(getAncestorHighlightable(entry.target.firstChild as Node), false, terms));
 				}
 			} else {
 				//console.log(entry.target, "not intersecting");
-				if (paintUsePaintingFallback && entry.target[ElementProperty.INFO]) {
-					document.getElementById(getSel(ElementID.DRAW_ELEMENT, (entry.target[ElementProperty.INFO] as ElementInfo).id))?.remove();
+				if (paintUsePaintingFallback && entry.target[EleProperty.INFO]) {
+					document.getElementById(getElementDrawId((entry.target[EleProperty.INFO] as ElementInfo).id))?.remove();
 				}
 				elementsVisible.delete(entry.target);
 				shiftObserver.unobserve(entry.target);
@@ -2858,8 +3136,8 @@ const getTermsFromSelection = () => {
 			.filter(phrase => phrase !== "").map(phrase => new MatchTerm(phrase));
 		const termSelectors: Set<string> = new Set;
 		termsAll.forEach(term => {
-			if (!termSelectors.has(term.selector)) {
-				termSelectors.add(term.selector);
+			if (!termSelectors.has(term.token)) {
+				termSelectors.add(term.token);
 				terms.push(term);
 			}
 		});
@@ -2896,7 +3174,7 @@ const getTermsFromSelection = () => {
 		const insertToolbar = (terms: MatchTerms, controlsInfo: ControlsInfo, commands: BrowserCommands,
 			highlightTags: HighlightTags, hues: TermHues, produceEffectOnCommand: ProduceEffectOnCommand) => {
 			const focusingControlAppend = document.activeElement && document.activeElement.tagName === "INPUT"
-				&& document.activeElement.closest(`#${getSel(ElementID.BAR)}`);
+				&& document.activeElement.closest(`#${EleID.BAR}`);
 			controlsRemove();
 			controlsInsert(terms, controlsInfo, commands, highlightTags, hues, produceEffectOnCommand);
 			if (focusingControlAppend) {
@@ -2907,12 +3185,16 @@ const getTermsFromSelection = () => {
 		};
 	
 		return (terms: MatchTerms,
-			controlsInfo: ControlsInfo, commands: BrowserCommands,
-			highlightTags: HighlightTags, hues: TermHues,
-			mutationUpdates: MutationUpdates, termCountCheck: TermCountCheck,
+			controlsInfo: ControlsInfo,
+			commands: BrowserCommands,
+			highlightTags: HighlightTags,
+			hues: TermHues,
+			mutationUpdates: MutationUpdates,
+			termCountCheck: TermCountCheck,
 			produceEffectOnCommand: ProduceEffectOnCommand,
 			getHighlightingId: GetHighlightingID,
-			styleUpdates: StyleUpdates, elementsVisible: Set<Element>,
+			styleUpdates: StyleUpdates,
+			elementsVisible: Set<Element>,
 			termsUpdate?: MatchTerms,
 		) => {
 			// TODO fix this abomination of a function
@@ -2959,7 +3241,7 @@ const getTermsFromSelection = () => {
 			}
 			const termsToHighlight: MatchTerms = [];
 			const termsToPurge: MatchTerms = [];
-			if (document.getElementById(getSel(ElementID.BAR))) {
+			if (document.getElementById(EleID.BAR)) {
 				if (termsUpdate !== undefined && termToUpdateIdx !== undefined
 					&& termToUpdateIdx !== TermChange.REMOVE && termUpdate) {
 					if (termToUpdateIdx === TermChange.CREATE) {
@@ -2985,7 +3267,7 @@ const getTermsFromSelection = () => {
 						)) {
 							removeTermControl(termRemovedPreviousIdx);
 							boxesInfoRemoveForTerms([ terms[termRemovedPreviousIdx] ]);
-							elementsRestore([ getSel(ElementClass.TERM, terms[termRemovedPreviousIdx].selector) ]);
+							elementsRestore([ getTermClass(terms[termRemovedPreviousIdx].token) ]);
 							terms.splice(termRemovedPreviousIdx, 1);
 							fillStylesheetContent(terms, hues, controlsInfo);
 							termCountCheck();
@@ -3014,8 +3296,8 @@ const getTermsFromSelection = () => {
 			}
 			fillStylesheetContent(terms, hues, controlsInfo);
 			if (!controlsInfo.pageModifyEnabled) {
-				const bar = document.getElementById(getSel(ElementID.BAR)) as Element;
-				bar.classList.add(getSel(ElementClass.DISABLED));
+				const bar = document.getElementById(EleID.BAR) as Element;
+				bar.classList.add(EleClass.DISABLED);
 				return;
 			}
 			if (controlsInfo.paintReplaceByClassic) {
@@ -3045,29 +3327,29 @@ const getTermsFromSelection = () => {
 	 * Inserts a uniquely identified CSS stylesheet to perform all extension styling.
 	 */
 	const styleElementsInsert = () => {
-		if (!document.getElementById(getSel(ElementID.STYLE))) {
+		if (!document.getElementById(EleID.STYLE)) {
 			const style = document.createElement("style");
-			style.id = getSel(ElementID.STYLE);
+			style.id = EleID.STYLE;
 			document.head.appendChild(style);
 		}
-		if (!document.getElementById(getSel(ElementID.STYLE_PAINT))) {
+		if (!document.getElementById(EleID.STYLE_PAINT)) {
 			const style = document.createElement("style");
-			style.id = getSel(ElementID.STYLE_PAINT);
+			style.id = EleID.STYLE_PAINT;
 			document.head.appendChild(style);
 		}
-		if (!document.getElementById(getSel(ElementID.DRAW_CONTAINER))) {
+		if (!document.getElementById(EleID.DRAW_CONTAINER)) {
 			const container = document.createElement("div");
-			container.id = getSel(ElementID.DRAW_CONTAINER);
+			container.id = EleID.DRAW_CONTAINER;
 			document.body.insertAdjacentElement("afterend", container);
 		}
 	};
 
 	const styleElementsCleanup = () => {
-		const style = document.getElementById(getSel(ElementID.STYLE));
+		const style = document.getElementById(EleID.STYLE);
 		if (style && style.textContent !== "") {
 			style.textContent = "";
 		}
-		const stylePaint = document.getElementById(getSel(ElementID.STYLE_PAINT)) as HTMLStyleElement | null;
+		const stylePaint = document.getElementById(EleID.STYLE_PAINT) as HTMLStyleElement | null;
 		if (stylePaint && stylePaint.sheet) {
 			while (stylePaint.sheet.cssRules.length) {
 				stylePaint.sheet.deleteRule(0);
@@ -3098,8 +3380,8 @@ const getTermsFromSelection = () => {
 			focusedIdx = getFocusedIdx(focusedIdx);
 			switch (commandInfo.type) {
 			case CommandType.TOGGLE_BAR: {
-				const bar = document.getElementById(getSel(ElementID.BAR)) as HTMLElement;
-				bar.classList.toggle(getSel(ElementClass.BAR_HIDDEN));
+				const bar = document.getElementById(EleID.BAR) as HTMLElement;
+				bar.classList.toggle(EleClass.BAR_HIDDEN);
 				break;
 			} case CommandType.TOGGLE_SELECT: {
 				selectModeFocus = !selectModeFocus;
@@ -3127,27 +3409,24 @@ const getTermsFromSelection = () => {
 				const selection = getSelection() as Selection;
 				const activeElementOriginal = document.activeElement as HTMLElement;
 				const selectionRangesOriginal = Array(selection.rangeCount).fill(null).map((v, i) => selection.getRangeAt(i));
-				control.classList.add(getSel(ElementClass.OVERRIDE_VISIBILITY));
 				input.focus();
 				input.select();
-				control.classList.remove(getSel(ElementClass.OVERRIDE_VISIBILITY));
-				selectInputTextAll(input);
-				if (activeElementOriginal && activeElementOriginal.closest(`#${getSel(ElementID.BAR)}`)) {
+				if (activeElementOriginal && activeElementOriginal.closest(`#${EleID.BAR}`)) {
 					break; // Focus was already in bar, so focus return should not be updated.
 				}
 				focusReturnInfo.element = activeElementOriginal;
 				focusReturnInfo.selectionRanges = selectionRangesOriginal;
-				const bar = document.getElementById(getSel(ElementID.BAR)) as HTMLElement;
+				const bar = document.getElementById(EleID.BAR) as HTMLElement;
 				const returnSelection = (event: FocusEvent) => {
 					if (event.relatedTarget) {
 						setTimeout(() => {
-							if (!document.activeElement || !document.activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+							if (!document.activeElement || !document.activeElement.closest(`#${EleID.BAR}`)) {
 								bar.removeEventListener("focusout", returnSelection);
 							}
 						});
 						return; // Focus is being moved, not lost.
 					}
-					if (document.activeElement && document.activeElement.closest(`#${getSel(ElementID.BAR)}`)) {
+					if (document.activeElement && document.activeElement.closest(`#${EleID.BAR}`)) {
 						return;
 					}
 					bar.removeEventListener("focusout", returnSelection);
@@ -3162,10 +3441,10 @@ const getTermsFromSelection = () => {
 				bar.addEventListener("focusout", returnSelection);
 				break;
 			} case CommandType.SELECT_TERM: {
-				const barTerms = document.getElementById(getSel(ElementID.BAR_TERMS)) as HTMLElement;
-				barTerms.classList.remove(getSel(ElementClass.CONTROL_PAD, focusedIdx));
+				const barTerms = document.getElementById(EleID.BAR_TERMS) as HTMLElement;
+				barTerms.classList.remove(getControlPadClass(focusedIdx));
 				focusedIdx = getFocusedIdx(commandInfo.termIdx as number);
-				barTerms.classList.add(getSel(ElementClass.CONTROL_PAD, focusedIdx));
+				barTerms.classList.add(getControlPadClass(focusedIdx));
 				if (!selectModeFocus) {
 					focusOnTermJump(controlsInfo, highlightTags, commandInfo.reversed as boolean,
 						terms[focusedIdx]);
@@ -3190,6 +3469,12 @@ const getTermsFromSelection = () => {
 	const getHighlightTagsSet = (tagsLower: Array<keyof HTMLElementTagNameMap>) =>
 		new Set(tagsLower.flatMap(tagLower => [ tagLower, tagLower.toUpperCase() ]))
 	;
+
+	const onWindowMouseUp = () => {
+		if (document.activeElement && document.activeElement.classList.contains(EleClass.CONTROL_REVEAL)) {
+			(document.querySelector(`#${EleID.BAR} .${EleClass.WAS_FOCUSED}`) as HTMLElement | null)?.focus();
+		}
+	};
 
 	return () => {
 		if (!paintUsePaintingFallback) {
@@ -3233,7 +3518,7 @@ const getTermsFromSelection = () => {
 		const highlightTags: HighlightTags = {
 			reject: getHighlightTagsSet([ "meta", "style", "script", "noscript", "title", "textarea" ]),
 			flow: getHighlightTagsSet([ "b", "i", "u", "strong", "em", "cite", "span", "mark", "wbr", "code", "data", "dfn", "ins",
-				"mms-h" as keyof HTMLElementTagNameMap ]),
+				HIGHLIGHT_TAG as keyof HTMLElementTagNameMap ]),
 			// break: any other class of element
 		};
 		const termCountCheck = (() => {
@@ -3313,6 +3598,7 @@ const getTermsFromSelection = () => {
 				controlsInfo.termsOnHold = message.termsOnHold;
 			}
 			if (message.deactivate) {
+				window.removeEventListener("mouseup", onWindowMouseUp);
 				mutationUpdates.disconnect();
 				styleUpdates.disconnectAll();
 				terms.splice(0);
@@ -3320,13 +3606,14 @@ const getTermsFromSelection = () => {
 				elementsRestore();
 				styleElementsCleanup();
 				document.querySelectorAll("*").forEach(element => {
-					delete element[ElementProperty.INFO];
+					delete element[EleProperty.INFO];
 				});
 				highlightingAttributesCleanup(document.body);
 			}
 			if (message.terms !== undefined &&
-				(!itemsMatch(terms, message.terms, termEquals) || (!terms.length && !document.getElementById(ElementID.BAR)))
+				(!itemsMatch(terms, message.terms, termEquals) || (!terms.length && !document.getElementById(EleID.BAR)))
 			) {
+				window.addEventListener("mouseup", onWindowMouseUp);
 				refreshTermControlsAndBeginHighlighting(
 					terms, //
 					controlsInfo, commands, //
@@ -3342,10 +3629,10 @@ const getTermsFromSelection = () => {
 				produceEffectOnCommand.next(command);
 			});
 			controlVisibilityUpdate("replaceTerms", controlsInfo, terms);
-			const bar = document.getElementById(getSel(ElementID.BAR));
+			const bar = document.getElementById(EleID.BAR);
 			if (bar) {
-				bar.classList.toggle(getSel(ElementClass.HIGHLIGHTS_SHOWN), controlsInfo.highlightsShown);
-				bar.classList.toggle(getSel(ElementClass.COLLAPSED), controlsInfo.barCollapsed);
+				bar.classList.toggle(EleClass.HIGHLIGHTS_SHOWN, controlsInfo.highlightsShown);
+				bar.classList.toggle(EleClass.COLLAPSED, controlsInfo.barCollapsed);
 			}
 		};
 		(() => {

--- a/src/include/utility.ts
+++ b/src/include/utility.ts
@@ -75,7 +75,7 @@ interface MatchMode {
  */
 class MatchTerm {
 	phrase: string;
-	selector: string;
+	token: string;
 	pattern: RegExp;
 	matchMode: MatchMode;
 	hue: number;
@@ -112,7 +112,7 @@ class MatchTerm {
 		const sanitize: (phrase: string, replacement?: string) => string = this.matchMode.regex
 			? phrase => phrase
 			: (phrase, replacement) => sanitizeForRegex(phrase, replacement);
-		this.selector = `${
+		this.token = `${
 			sanitize(this.phrase, "_").replace(/\W/g, "_")
 		}-${
 			Object.values(this.matchMode).map((matchFlag: boolean) => Number(matchFlag)).join("")

--- a/src/paint.ts
+++ b/src/paint.ts
@@ -20,7 +20,7 @@ type PaintWorkletType = {
 		const selectorStyles = JSON.parse(properties.get("--markmysearch-styles").toString() || "{}") as TermSelectorStyles;
 		const boxes = JSON.parse(properties.get("--markmysearch-boxes").toString() || "[]") as Array<HighlightBox>;
 		boxes.forEach(box => {
-			const style = selectorStyles[box.selector];
+			const style = selectorStyles[box.token];
 			if (!style) {
 				return;
 			}


### PR DESCRIPTION
- Change match-mode select menu to present checkboxes, multiple of which
  can be toggled without closing the menu
- Refactor content script, improve consistency
- Automatically clean up empty nodes when removing highlighting
- Make package build scripts delete `dist` first
- Fix jump area flashing on PAINT "element"