### PR TITLE
Restructure PaintEngine

### DIFF
--- a/src/include/utility.ts
+++ b/src/include/utility.ts
@@ -1,9 +1,28 @@
 type MatchTerms = Array<MatchTerm>
 
+/**
+ * @deprecated Use `compatibility.browser` instead.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const useChromeAPI = () =>
-	!this.browser
-;
+const useChromeAPI = () => !this.browser;
+
+enum Browser {
+	UNKNOWN,
+	FIREFOX,
+	CHROMIUM,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const compatibility = {
+	browser: Browser.UNKNOWN,
+	highlight: {
+		paintEngine: {
+			paintMethod: !!CSS.paintWorklet,
+			elementMethod: !!document["mozSetImageElement"], // Could return false negatives - `element()` might be defined anyway.
+			highlightMethod: !!CSS.highlights,
+		},
+	},
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const [ Z_INDEX_MIN, Z_INDEX_MAX ] = [ -(2**31), 2**31 - 1 ];


### PR DESCRIPTION
- Divide PaintEngine internals into 2 categories: core, and method-specific
- Separate PaintEngine method-specific internals out into 3 method implementations: PaintMethod, ElementMethod, UrlMethod