### PR TITLE
Fix association of match modes in popup

### DIFF
--- a/src/pages/popup-build.ts
+++ b/src/pages/popup-build.ts
@@ -415,8 +415,8 @@ const loadPopup = (() => {
 									{
 										className: "matching",
 										rows: [
-											getMatchModeInteractionInfo("whole", "Stemming"),
-											getMatchModeInteractionInfo("stem", "Whole Words"),
+											getMatchModeInteractionInfo("stem", "Stemming"),
+											getMatchModeInteractionInfo("whole", "Whole Words"),
 											getMatchModeInteractionInfo("case", "Case Sensitive"),
 											getMatchModeInteractionInfo("diacritics", "Diacritics Insensitive"),
 											getMatchModeInteractionInfo("regex", "Regular Expression"),


### PR DESCRIPTION
- Fetch "Stemming" match mode using "stem" and "Whole Words" using "whole" (instead of these being swapped)