### PR TITLE
Improve conventions, clean up highlighting code

### DIFF
--- a/src/modules/highlight/engine.mts
+++ b/src/modules/highlight/engine.mts
@@ -36,15 +36,15 @@ interface AbstractEngine {
 	 * @param termsToPurge Terms for which to remove previous highlights.
 	 */
 	startHighlighting: (
-		terms: Array<MatchTerm>,
-		termsToHighlight: Array<MatchTerm>,
-		termsToPurge: Array<MatchTerm>,
-		hues: Array<number>,
+		terms: ReadonlyArray<MatchTerm>,
+		termsToHighlight: ReadonlyArray<MatchTerm>,
+		termsToPurge: ReadonlyArray<MatchTerm>,
+		hues: ReadonlyArray<number>,
 	) => void
 	
 	// TODO document
 	undoHighlights: (
-		terms?: Array<MatchTerm> | undefined,
+		terms?: ReadonlyArray<MatchTerm> | undefined,
 	) => void
 
 	// TODO document

--- a/src/modules/highlight/engines/paint/boxes.mts
+++ b/src/modules/highlight/engines/paint/boxes.mts
@@ -1,6 +1,6 @@
 import { highlightTags } from "/dist/modules/highlight/highlight-tags.mjs";
 import { CACHE } from "/dist/modules/highlight/models/tree-cache/tree-cache.mjs";
-import type { TreeCache, Flow, Box } from "/dist/modules/highlight/engines/paint.mjs";
+import type { Flow, Box, CachingElement } from "/dist/modules/highlight/engines/paint.mjs";
 import type { TermTokens } from "/dist/modules/match-term.mjs";
 
 const getBoxesOwned = (
@@ -9,13 +9,13 @@ const getBoxesOwned = (
 	range = new Range(),
 ): Array<Box> => {
 	let boxes = getBoxes(termTokens, owner, owner, range);
-	const walker = document.createTreeWalker(owner, NodeFilter.SHOW_ELEMENT, (element: Element) =>
-		highlightTags.reject.has(element.tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+	const walker = document.createTreeWalker(owner, NodeFilter.SHOW_ELEMENT, element =>
+		highlightTags.reject.has((element as Element).tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
 	);
-	let child: Element;
+	let child: CachingElement;
 	// eslint-disable-next-line no-cond-assign
-	while (child = walker.nextNode() as Element) {
-		if (CACHE in child && !(child[CACHE] as TreeCache).isHighlightable) {
+	while (child = walker.nextNode() as CachingElement) {
+		if (CACHE in child && !child[CACHE].isHighlightable) {
 			boxes = boxes.concat(getBoxes(termTokens, owner, child, range));
 		}
 	}
@@ -24,21 +24,20 @@ const getBoxesOwned = (
 
 const getBoxes = (
 	termTokens: TermTokens,
-	owner: Element,
-	element?: Element,
+	owner: CachingElement,
+	element?: CachingElement,
 	range = new Range(),
 ) => {
 	element ??= owner;
-	const highlighting = element[CACHE] as TreeCache;
-	if (!highlighting || highlighting.flows.every(flow => flow.boxesInfo.length === 0)) {
+	if (!(CACHE in element) || element[CACHE].flows.every(flow => flow.boxesInfo.length === 0)) {
 		return [];
 	}
 	let ownerRects = Array.from(owner.getClientRects());
 	if (!ownerRects.length) {
 		ownerRects = [ owner.getBoundingClientRect() ];
 	}
-	elementPopulateBoxes(highlighting.flows, ownerRects, termTokens, range);
-	return highlighting.flows.flatMap(flow => flow.boxesInfo.flatMap(boxInfo => boxInfo.boxes ?? []));
+	elementPopulateBoxes(element[CACHE].flows, ownerRects, termTokens, range);
+	return element[CACHE].flows.flatMap(flow => flow.boxesInfo.flatMap(boxInfo => boxInfo.boxes ?? []));
 };
 
 const elementPopulateBoxes = (
@@ -46,8 +45,8 @@ const elementPopulateBoxes = (
 	elementRects: Array<DOMRect>,
 	termTokens: TermTokens,
 	range = new Range(),
-) =>
-	elementFlows.forEach(flow => flow.boxesInfo.forEach(boxInfo => {
+) => {
+	for (const flow of elementFlows) for (const boxInfo of flow.boxesInfo) {
 		boxInfo.boxes?.splice(0);
 		range.setStart(boxInfo.node, boxInfo.start);
 		range.setEnd(boxInfo.node, boxInfo.end);
@@ -56,7 +55,8 @@ const elementPopulateBoxes = (
 			const textRect = textRects.item(i) as DOMRect;
 			if (i !== 0
 				&& textRect.x === (textRects.item(i - 1) as DOMRect).x
-				&& textRect.y === (textRects.item(i - 1) as DOMRect).y) {
+				&& textRect.y === (textRects.item(i - 1) as DOMRect).y
+			) {
 				continue;
 			}
 			let x = 0;
@@ -79,7 +79,7 @@ const elementPopulateBoxes = (
 				height: Math.round(textRect.height),
 			});
 		}
-	}))
-;
+	}
+};
 
 export { getBoxesOwned };

--- a/src/modules/highlight/engines/paint/highlightables.mts
+++ b/src/modules/highlight/engines/paint/highlightables.mts
@@ -1,7 +1,9 @@
-type Highlightables = Readonly<{
-	checkElement: (node: Node) => boolean
+import type { CachingElement } from "/dist/modules/highlight/engines/paint.mjs";
 
-	findAncestor: <T extends Element>(element: T) => T
+interface Highlightables {
+	isElementHighlightable: (element: Element) => boolean
+
+	findHighlightableAncestor: (element: CachingElement) => CachingElement
 
 	/**
 	 * From the element specified (included) to its highest ancestor element (not included),
@@ -9,7 +11,7 @@ type Highlightables = Readonly<{
 	 * This allows them to be selected in CSS.
 	 * @param element The lowest descendant to be marked of the highlightable element.
 	 */
-	markElementsUpTo: (element: Element) => void
-}>
+	markElementsUpToHighlightable: (element: Element) => void
+}
 
 export type { Highlightables };

--- a/src/modules/highlight/engines/paint/method.mts
+++ b/src/modules/highlight/engines/paint/method.mts
@@ -1,16 +1,14 @@
-import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
+import type { Box, CachingElement, CachingHTMLElement } from "/dist/modules/highlight/engines/paint.mjs";
 import type { Highlightables } from "/dist/modules/highlight/engines/paint/highlightables.mjs";
 import type { EngineCSS } from "/dist/modules/highlight/engine.mjs";
 import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
-interface AbstractMethod {
-	highlightables: Highlightables
-
+interface AbstractMethod extends Highlightables {
 	getCSS: EngineCSS
 
 	endHighlighting: () => void
 
-	getHighlightedElements: () => NodeListOf<HTMLElement>
+	getHighlightedElements: () => NodeListOf<CachingHTMLElement<true>>
 
 	/**
 	 * Gets a CSS rule to style all elements as per the enabled PAINT variant.
@@ -18,11 +16,11 @@ interface AbstractMethod {
 	 * @param boxes Details of the highlight boxes to be painted. May not be required depending on the PAINT variant in use.
 	 * @param terms Terms currently being highlighted. Some PAINT variants use this information at this point.
 	 */
-	constructHighlightStyleRule: (highlightId: string, boxes: Array<Box>, terms: Array<MatchTerm>, hues: Array<number>) => string
+	constructHighlightStyleRule: (highlightId: string, boxes: Array<Box>, terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) => string
 
-	tempReplaceContainers: (root: Element, recurse: boolean) => void
+	tempReplaceContainers: (root: CachingElement<true>, recurse: boolean) => void
 
-	tempRemoveDrawElement: (element: Element) => void
+	tempRemoveDrawElement: (element: CachingElement<true>) => void
 }
 
 export type { AbstractMethod };

--- a/src/modules/highlight/engines/paint/methods/url.mts
+++ b/src/modules/highlight/engines/paint/methods/url.mts
@@ -1,6 +1,5 @@
 import type { AbstractMethod } from "/dist/modules/highlight/engines/paint/method.mjs";
-import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
-import type { Highlightables } from "/dist/modules/highlight/engines/paint/highlightables.mjs";
+import type { Box, CachingElement, CachingHTMLElement } from "/dist/modules/highlight/engines/paint.mjs";
 import type { EngineCSS } from "/dist/modules/highlight/engine.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import { EleID, EleClass } from "/dist/modules/common.mjs";
@@ -12,11 +11,15 @@ class UrlMethod implements AbstractMethod {
 		this.termTokens = termTokens;
 	}
 
-	readonly highlightables: Highlightables = {
-		checkElement: () => true,
-		findAncestor: <T extends Element> (element: T) => element,
-		markElementsUpTo: () => undefined,
-	};
+	isElementHighlightable () {
+		return true;
+	}
+
+	findHighlightableAncestor (element: CachingElement): CachingElement {
+		return element;
+	}
+
+	markElementsUpToHighlightable () {}
 
 	readonly getCSS: EngineCSS = {
 		misc: () => "",
@@ -27,16 +30,18 @@ class UrlMethod implements AbstractMethod {
 	endHighlighting () {}
 
 	getHighlightedElements () {
-		return document.body.querySelectorAll("[markmysearch-h_id]") as NodeListOf<HTMLElement>;
+		return document.body.querySelectorAll(
+			"[markmysearch-h_id]",
+		) as NodeListOf<CachingHTMLElement<true>>;
 	}
 
-	constructHighlightStyleRule (highlightId: string, boxes: Array<Box>, terms: Array<MatchTerm>, hues: Array<number>) {
+	constructHighlightStyleRule (highlightId: string, boxes: Array<Box>, terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) {
 		return `#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body [markmysearch-h_id="${highlightId}"] { background-image: ${
 			this.constructHighlightStyleRuleUrl(boxes, terms, hues)
 		} !important; background-repeat: no-repeat !important; }`;
 	}
 
-	constructHighlightStyleRuleUrl (boxes: Array<Box>, terms: Array<MatchTerm>, hues: Array<number>) {
+	constructHighlightStyleRuleUrl (boxes: Array<Box>, terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) {
 		return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E${
 			boxes.map(box =>
 				`%3Crect width='${box.width}' height='${box.height}' x='${box.x}' y='${box.y}' fill='hsl(${

--- a/src/modules/highlight/models/term-marker.mts
+++ b/src/modules/highlight/models/term-marker.mts
@@ -1,5 +1,4 @@
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
-import type { TermHues } from "/dist/modules/common.mjs";
 
 interface AbstractTermMarker {
 	/**
@@ -8,9 +7,9 @@ interface AbstractTermMarker {
 	 * @param hues Color hues for term styles to cycle through.
 	 */
 	insert: (
-		terms: Array<MatchTerm>,
+		terms: ReadonlyArray<MatchTerm>,
 		termTokens: TermTokens,
-		hues: TermHues,
+		hues: ReadonlyArray<number>,
 		highlightedElements: Iterable<HTMLElement>,
 	) => void
 

--- a/src/modules/highlight/models/tree-cache/flow-monitor.mts
+++ b/src/modules/highlight/models/tree-cache/flow-monitor.mts
@@ -1,16 +1,16 @@
 import type { MatchTerm, TermPatterns } from "/dist/modules/match-term.mjs";
 
 interface AbstractFlowMonitor {
-	mutationObserver: MutationObserver;
+	mutationObserver: MutationObserver
 
 	generateBoxesInfo: (
-		terms: Array<MatchTerm>,
+		terms: ReadonlyArray<MatchTerm>,
 		termPatterns: TermPatterns,
 		flowOwner: HTMLElement,
 	) => void
 
 	removeBoxesInfo: (
-		terms?: Array<MatchTerm>,
+		terms?: ReadonlyArray<MatchTerm>,
 		root?: HTMLElement,
 	) => void
 }

--- a/src/modules/highlight/models/tree-cache/term-counters/term-counter.mts
+++ b/src/modules/highlight/models/tree-cache/term-counters/term-counter.mts
@@ -1,20 +1,27 @@
 import type { AbstractTermCounter } from "/dist/modules/highlight/models/term-counter.mjs";
-import { type TreeCache, CACHE } from "/dist/modules/highlight/models/tree-cache/tree-cache.mjs";
+import { type CachingElement, CACHE } from "/dist/modules/highlight/models/tree-cache/tree-cache.mjs";
+import type { BaseFlow } from "/dist/modules/highlight/matcher.mjs";
 import { highlightTags } from "/dist/modules/highlight/highlight-tags.mjs";
 import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
+type Flow = BaseFlow<false>
+
 class TermCounter implements AbstractTermCounter {
 	countBetter (term: MatchTerm) {
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: Element) =>
-			highlightTags.reject.has(element.tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, element =>
+			highlightTags.reject.has((element as Element).tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
 		);
 		let count = 0;
-		let element: Element & { [CACHE]?: TreeCache };
+		let element: CachingElement<Flow>;
 		// eslint-disable-next-line no-cond-assign
-		while (element = walker.nextNode() as Element) {
-			element[CACHE]?.flows.forEach(flow => {
-				count += flow.boxesInfo.filter(boxInfo => boxInfo.term === term).length;
-			});
+		while (element = walker.nextNode() as CachingElement<Flow>) if (CACHE in element) {
+			for (const flow of element[CACHE].flows) {
+				for (const boxInfo of flow.boxesInfo) {
+					if (boxInfo.term === term) {
+						count++;
+					}
+				}
+			}
 		}
 		return count;
 	}
@@ -22,13 +29,13 @@ class TermCounter implements AbstractTermCounter {
 	readonly countFaster = this.countBetter;
 
 	exists (term: MatchTerm) {
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: Element) =>
-			highlightTags.reject.has(element.tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, element =>
+			highlightTags.reject.has((element as Element).tagName) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
 		);
-		let element: Element & { [CACHE]?: TreeCache };
+		let element: CachingElement<Flow>;
 		// eslint-disable-next-line no-cond-assign
-		while (element = walker.nextNode() as Element) {
-			if (element[CACHE]?.flows.some(flow =>
+		while (element = walker.nextNode() as CachingElement<Flow>) {
+			if (CACHE in element && element[CACHE].flows.some(flow =>
 				flow.boxesInfo.filter(boxInfo => boxInfo.term === term).length > 0
 			)) {
 				return true;

--- a/src/modules/highlight/models/tree-cache/term-walkers/term-walker.mts
+++ b/src/modules/highlight/models/tree-cache/term-walkers/term-walker.mts
@@ -1,7 +1,10 @@
 import type { AbstractTermWalker } from "/dist/modules/highlight/models/term-walker.mjs";
-import { type TreeCache, CACHE } from "/dist/modules/highlight/models/tree-cache/tree-cache.mjs";
+import { type CachingHTMLElement, CACHE } from "/dist/modules/highlight/models/tree-cache/tree-cache.mjs";
+import type { BaseFlow } from "/dist/modules/highlight/matcher.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import { EleID, EleClass, getNodeFinal, isVisible, elementsPurgeClass, focusClosest } from "/dist/modules/common.mjs";
+
+type Flow = BaseFlow<false>
 
 class TermWalker implements AbstractTermWalker {
 	step (
@@ -10,7 +13,7 @@ class TermWalker implements AbstractTermWalker {
 		term: MatchTerm | null,
 		termTokens: TermTokens,
 		nodeStart?: Node,
-	): HTMLElement | null {
+	): CachingHTMLElement<Flow> | null {
 		elementsPurgeClass(EleClass.FOCUS_CONTAINER);
 		const selection = document.getSelection() as Selection;
 		const bar = document.getElementById(EleID.BAR) as HTMLElement;
@@ -26,19 +29,28 @@ class TermWalker implements AbstractTermWalker {
 				? (nodeSelected ? (nodeFocused.contains(nodeSelected) ? nodeSelected : nodeFocused) : nodeFocused)
 				: nodeSelected ?? nodeBegin
 			);
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement & { [CACHE]?: TreeCache }) =>
-			element[CACHE]?.flows.some(flow =>
-				term ? flow.boxesInfo.some(boxInfo => boxInfo.term === term) : flow.boxesInfo.length
-			) && isVisible(element)
-				? NodeFilter.FILTER_ACCEPT
-				: NodeFilter.FILTER_SKIP
+		const walker = document.createTreeWalker(
+			document.body,
+			NodeFilter.SHOW_ELEMENT,
+			(term
+				// If a term has been passed, we are looking for elements with at least 1 occurrence of that term.
+				? element => (CACHE in element
+					&& element[CACHE].flows.some(flow => flow.boxesInfo.some(boxInfo => boxInfo.term === term))
+					&& isVisible(element)
+				) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+				// If NO term has been passed, we are looking for elements with any highlighting.
+				: element => (CACHE in element
+					&& element[CACHE].flows.some(flow => flow.boxesInfo.length > 0)
+					&& isVisible(element)
+				) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+			) as ((element: CachingHTMLElement<Flow>) => number) as (node: Node) => number,
 		);
 		walker.currentNode = nodeCurrent;
 		const nextNodeMethod = reverse ? "previousNode" : "nextNode";
 		if (nodeFocused) {
 			nodeFocused.blur();
 		}
-		const element = walker[nextNodeMethod]() as HTMLElement | null;
+		const element = walker[nextNodeMethod]() as CachingHTMLElement<Flow> | null;
 		if (!element) {
 			if (!nodeStart) {
 				this.step(reverse, stepNotJump, term, termTokens, nodeBegin);
@@ -48,9 +60,7 @@ class TermWalker implements AbstractTermWalker {
 		if (!stepNotJump) {
 			element.classList.add(EleClass.FOCUS_CONTAINER);
 		}
-		focusClosest(element, element =>
-			element[CACHE] && (element[CACHE] as TreeCache).flows.length > 0
-		);
+		focusClosest(element, element => CACHE in element && element[CACHE].flows.length > 0);
 		selection.setBaseAndExtent(element, 0, element, 0);
 		element.scrollIntoView({ behavior: stepNotJump ? "auto" : "smooth", block: "center" });
 		return element;

--- a/src/modules/highlight/models/tree-cache/tree-cache.mts
+++ b/src/modules/highlight/models/tree-cache/tree-cache.mts
@@ -1,18 +1,39 @@
 import type { BaseFlow } from "/dist/modules/highlight/matcher.mjs";
 
-type TreeCache<Flow = BaseFlow<false>> = {
+type TreeCache<Flow extends BaseFlow<false>> = {
 	flows: Array<Flow>
 }
 
-type CachingElement<Flow = BaseFlow<true>> = Element & { [CACHE]: TreeCache<Flow> }
+type CachingElement<Flow extends BaseFlow<false>, HasCache = false> = (
+	BaseCachingElement<TreeCache<Flow>, HasCache>
+)
 
-type CachingHTMLElement<Flow = BaseFlow<true>> = HTMLElement & { [CACHE]: TreeCache<Flow> }
+type CachingHTMLElement<Flow extends BaseFlow<false>, HasCache = false> = (
+	BaseCachingHTMLElement<TreeCache<Flow>, HasCache>
+)
+
+type BaseCachingElement<TC extends TreeCache<BaseFlow<false>>, HasCache = false> = (
+	BaseCachingE<Element, TC, HasCache>
+)
+
+type BaseCachingHTMLElement<TC extends TreeCache<BaseFlow<false>>, HasCache = false> = (
+	BaseCachingE<HTMLElement, TC, HasCache>
+)
+
+type UnknownCachingElement = Element & { [CACHE]: unknown }
+
+type UnknownCachingHTMLElement = HTMLElement & { [CACHE]: unknown }
+
+type BaseCachingE<E extends Element, TC extends TreeCache<BaseFlow<false>>, C = false> = (C extends true
+	? (E & { [CACHE]: TC })
+	: (E | (E & { [CACHE]: TC }))
+)
 
 const CACHE = "markmysearch__cache";
 
 export {
 	type TreeCache,
-	type CachingElement as CachingElement,
-	type CachingHTMLElement as CachingHTMLElement,
+	type BaseCachingElement, type CachingElement, type UnknownCachingElement,
+	type BaseCachingHTMLElement, type CachingHTMLElement, type UnknownCachingHTMLElement,
 	CACHE,
 };

--- a/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
+++ b/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
@@ -4,11 +4,16 @@ import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import {
 	EleID, EleClass,
 	getElementYRelative, elementsPurgeClass,
-	type TermHues, getTermClass, getTermClassToken,
+	getTermClass, getTermClassToken,
 } from "/dist/modules/common.mjs";
 
 class TermMarker implements AbstractTermMarker {
-	insert (terms: Array<MatchTerm>, termTokens: TermTokens, hues: TermHues, highlightedElements: Iterable<HTMLElement>) {
+	insert (
+		terms: ReadonlyArray<MatchTerm>,
+		termTokens: TermTokens,
+		hues: ReadonlyArray<number>,
+		highlightedElements: Iterable<HTMLElement>,
+	) {
 		if (terms.length === 0) {
 			return; // No terms results in an empty selector, which is not allowed.
 		}

--- a/src/modules/highlight/models/tree-edit/term-walkers/term-walker.mts
+++ b/src/modules/highlight/models/tree-edit/term-walkers/term-walker.mts
@@ -125,13 +125,18 @@ class TermWalker implements AbstractTermWalker {
 					: selectionFocus.parentElement,
 			) : undefined;
 		const walkSelectionFocusContainer = { accept: false };
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement) =>
-			element.tagName === HIGHLIGHT_TAG_UPPER
-			&& (termSelector ? element.classList.contains(termSelector) : true)
-			&& isVisible(element)
-			&& (getContainerBlock(element) !== selectionFocusContainer || walkSelectionFocusContainer.accept)
-				? NodeFilter.FILTER_ACCEPT
-				: NodeFilter.FILTER_SKIP);
+		const walker = document.createTreeWalker(
+			document.body,
+			NodeFilter.SHOW_ELEMENT,
+			(element =>
+				element.tagName === HIGHLIGHT_TAG_UPPER
+				&& (termSelector ? element.classList.contains(termSelector) : true)
+				&& isVisible(element)
+				&& (getContainerBlock(element) !== selectionFocusContainer || walkSelectionFocusContainer.accept)
+					? NodeFilter.FILTER_ACCEPT
+					: NodeFilter.FILTER_SKIP
+			) as ((element: HTMLElement) => number) as (node: Node) => number,
+		);
 		walker.currentNode = selectionFocus ? selectionFocus : document.body;
 		const { elementSelected, container } = this.selectNextElement(reverse, walker, walkSelectionFocusContainer);
 		if (!elementSelected || !container) {
@@ -141,9 +146,9 @@ class TermWalker implements AbstractTermWalker {
 		if (selection) {
 			selection.setBaseAndExtent(elementSelected, 0, elementSelected, 0);
 		}
-		document.body.querySelectorAll(`.${EleClass.REMOVE}`).forEach((element: HTMLElement) => {
+		for (const element of document.body.querySelectorAll(`.${EleClass.REMOVE}`)) {
 			element.remove();
-		});
+		}
 		return elementSelected;
 	}
 
@@ -208,12 +213,16 @@ class TermWalker implements AbstractTermWalker {
 		if (document.activeElement) {
 			(document.activeElement as HTMLElement).blur();
 		}
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, (element: HTMLElement) =>
-			(element.parentElement as Element).closest(HIGHLIGHT_TAG)
-				? NodeFilter.FILTER_REJECT
-				: (element.tagName === HIGHLIGHT_TAG_UPPER && isVisible(element))
-					? NodeFilter.FILTER_ACCEPT
-					: NodeFilter.FILTER_SKIP
+		const walker = document.createTreeWalker(
+			document.body,
+			NodeFilter.SHOW_ELEMENT,
+			(element =>
+				(element.parentElement as Element).closest(HIGHLIGHT_TAG)
+					? NodeFilter.FILTER_REJECT
+					: (element.tagName === HIGHLIGHT_TAG_UPPER && isVisible(element))
+						? NodeFilter.FILTER_ACCEPT
+						: NodeFilter.FILTER_SKIP
+			) as ((element: HTMLElement) => number) as (node: Node) => number,
 		);
 		walker.currentNode = nodeCurrent;
 		const element = walker[reverse ? "previousNode" : "nextNode"]() as HTMLElement | null;
@@ -237,11 +246,12 @@ const elementsReMakeUnfocusable = (root: HTMLElement | DocumentFragment = docume
 	if (!root.parentNode) {
 		return;
 	}
-	root.parentNode.querySelectorAll(`.${EleClass.FOCUS_REVERT}`)
-		.forEach((element: HTMLElement) => {
-			element.tabIndex = -1;
-			element.classList.remove(EleClass.FOCUS_REVERT);
-		});
+	for (const element of root.parentNode.querySelectorAll(
+		`.${EleClass.FOCUS_REVERT}`,
+	) as NodeListOf<HTMLElement>) {
+		element.tabIndex = -1;
+		element.classList.remove(EleClass.FOCUS_REVERT);
+	}
 };
 
 export { TermWalker };

--- a/src/modules/highlight/special-engine.mts
+++ b/src/modules/highlight/special-engine.mts
@@ -1,7 +1,7 @@
 import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
 interface AbstractSpecialEngine {
-	startHighlighting: (terms: Array<MatchTerm>, hues: Array<number>) => void
+	startHighlighting: (terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) => void
 
 	endHighlighting: () => void
 

--- a/src/modules/interface/stylesheet.mts
+++ b/src/modules/interface/stylesheet.mts
@@ -1,5 +1,5 @@
 import { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
-import { type TermHues, EleID, EleClass, AtRuleID, getTermClass } from "/dist/modules/common.mjs";
+import { EleID, EleClass, AtRuleID, getTermClass } from "/dist/modules/common.mjs";
 import { getControlClass, getControlPadClass } from "/dist/modules/interface/toolbar/common.mjs";
 import type { Highlighter } from "/dist/modules/highlight/engine.mjs";
 import type { ControlsInfo } from "/dist/content.mjs";
@@ -13,7 +13,7 @@ import { Z_INDEX_MAX } from "/dist/modules/common.mjs";
 const fillContent = (
 	terms: ReadonlyArray<MatchTerm>,
 	termTokens: TermTokens,
-	hues: TermHues,
+	hues: ReadonlyArray<number>,
 	barLook: ControlsInfo["barLook"],
 	highlighter: Highlighter,
 ) => {
@@ -330,7 +330,8 @@ ${highlighter.current?.getCSS.misc() ?? ""}
 
 /**/`
 	;
-	terms.forEach((term, i) => {
+	for (let i = 0; i < terms.length; i++) {
+		const term = terms[i];
 		const hue = hues[i % hues.length];
 		const cycle = Math.floor(i / hues.length);
 		style.textContent += makeImportant(`
@@ -382,7 +383,7 @@ ${highlighter.current?.getCSS.termHighlight(terms, hues, i) ?? ""}
 
 /**/
 		`);
-	});
+	}
 };
 
 export { fillContent as fillContent };

--- a/src/modules/interface/toolbar.mts
+++ b/src/modules/interface/toolbar.mts
@@ -1,5 +1,5 @@
 import type { BrowserCommands } from "/dist/modules/interface/toolbar/common.mjs";
-import type { TermAbstractControl, TermControlInputInterface } from "/dist/modules/interface/toolbar/term-control.mjs";
+import type { TermControlInputInterface } from "/dist/modules/interface/toolbar/term-control.mjs";
 import type { ConfigBarControlsShown } from "/dist/modules/privileged/storage.mjs";
 import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
@@ -52,7 +52,7 @@ interface AbstractToolbar {
 }
 
 interface ToolbarTermControlInterface extends ToolbarTermInputInterface, ToolbarTermOptionListInterface {
-	getTermControlIndex: (control: TermAbstractControl) => number | null
+	getTermControlIndex: (control: TermControlInputInterface) => number | null
 
 	setAutofocusable: (autofocus: boolean) => void
 }

--- a/src/modules/interface/toolbars/toolbar.mts
+++ b/src/modules/interface/toolbars/toolbar.mts
@@ -4,14 +4,14 @@ import type {
 	ToolbarControlButtonInterface, ToolbarTermControlInterface,
 } from "/dist/modules/interface/toolbar.mjs";
 import { Control, type ControlButtonInfo } from "/dist/modules/interface/toolbar/control.mjs";
-import type { TermAbstractControl } from "/dist/modules/interface/toolbar/term-control.mjs";
+import type { TermAbstractControl, TermControlOptionListInterface } from "/dist/modules/interface/toolbar/term-control.mjs";
 import { TermReplaceControl } from "/dist/modules/interface/toolbar/term-controls/replace.mjs";
 import { TermAppendControl } from "/dist/modules/interface/toolbar/term-controls/append.mjs";
 import type { ControlFocusArea, BrowserCommands } from "/dist/modules/interface/toolbar/common.mjs";
 import { getControlPadClass, passKeyEvent } from "/dist/modules/interface/toolbar/common.mjs";
 import { sendBackgroundMessage } from "/dist/modules/messaging/background.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
-import { type TermHues, EleID, EleClass } from "/dist/modules/common.mjs";
+import { EleID, EleClass } from "/dist/modules/common.mjs";
 import type { Highlighter } from "/dist/modules/highlight/engine.mjs";
 import type { TermSetter, DoPhrasesMatchTerms, ControlsInfo } from "/dist/content.mjs";
 
@@ -44,7 +44,7 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 	constructor (
 		terms: ReadonlyArray<MatchTerm>,
 		commands: BrowserCommands,
-		hues: TermHues,
+		hues: ReadonlyArray<number>,
 		controlsInfo: ControlsInfo,
 		termSetter: TermSetter,
 		doPhrasesMatchTerms: DoPhrasesMatchTerms,
@@ -63,13 +63,14 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 		this.updateCollapsed();
 		// Inputs should not be focusable unless user has already focused bar. (1)
 		const inputsSetFocusable = (focusable: boolean) => {
-			this.#bar.querySelectorAll(`input.${EleClass.CONTROL_INPUT}`).forEach((input: HTMLElement) => {
+			const inputs = this.#bar.querySelectorAll(`input.${EleClass.CONTROL_INPUT}`) as NodeListOf<HTMLInputElement>;
+			for (const input of inputs) {
 				if (focusable) {
 					input.removeAttribute("tabindex");
 				} else {
 					input.tabIndex = -1;
 				}
-			});
+			}
 		};
 		this.#bar.addEventListener("focusin", () => {
 			inputsSetFocusable(true);
@@ -318,8 +319,8 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 		return this.#termControls.length;
 	}
 
-	getTermControlIndex (control: TermReplaceControl): number | null {
-		const index = this.#termControls.indexOf(control);
+	getTermControlIndex (control: TermControlOptionListInterface): number | null {
+		const index = this.#termControls.indexOf(control as TermReplaceControl);
 		if (index === -1) {
 			return null;
 		}

--- a/src/modules/messaging.mts
+++ b/src/modules/messaging.mts
@@ -4,10 +4,10 @@ import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
 type Tab = {
 	getDetails?: TabDetailsRequest
-	commands?: Array<CommandInfo>
-	extensionCommands?: Array<chrome.commands.Command>
-	terms?: Array<MatchTerm>
-	termsOnHold?: Array<MatchTerm>
+	commands?: ReadonlyArray<CommandInfo>
+	extensionCommands?: ReadonlyArray<chrome.commands.Command>
+	terms?: ReadonlyArray<MatchTerm>
+	termsOnHold?: ReadonlyArray<MatchTerm>
 	deactivate?: boolean
 	enablePageModify?: boolean
 	toggleHighlightsOn?: boolean
@@ -25,14 +25,14 @@ type TabDetailsRequest = {
 }
 
 type TabResponse = {
-	terms?: Array<MatchTerm>
+	terms?: ReadonlyArray<MatchTerm>
 	highlightsShown?: boolean
 }
 
 type Background<WithId = false> = {
-	highlightCommands?: Array<CommandInfo>
+	highlightCommands?: ReadonlyArray<CommandInfo>
 	initializationGet?: boolean
-	terms?: Array<MatchTerm>
+	terms?: ReadonlyArray<MatchTerm>
 	termsSend?: boolean
 	deactivateTabResearch?: boolean
 	performSearch?: boolean

--- a/src/modules/page/build.mts
+++ b/src/modules/page/build.mts
@@ -834,12 +834,14 @@ textarea
 		}, 1000);
 	};
 
-	const clearAlerts = (parent: HTMLElement, classNames: Array<Page.AlertType> = []) =>
-		parent.querySelectorAll(classNames.length
+	const clearAlerts = (parent: HTMLElement, classNames: Array<Page.AlertType> = []) => {
+		for (const alert of parent.querySelectorAll(classNames.length
 			? `.alert:is(${classNames.map(className => `.${className}`).join(", ")})`
 			: ".alert"
-		).forEach((alert: HTMLElement) => clearAlert(alert))
-	;
+		) as NodeListOf<HTMLElement>) {
+			clearAlert(alert);
+		}
+	};
 
 	const createSection = (() => {
 		const insertLabel = (container: HTMLElement, labelInfo: Page.InteractionInfo["label"], containerIndex: number) => {
@@ -947,8 +949,8 @@ textarea
 						if (textbox.parentElement) {
 							// Parent is a list container because getArrayForList exists
 							textboxInfo.list.setArray(
-								Array.from(textbox.parentElement.children)
-									.map((textbox: HTMLInputElement) => textbox.value)
+								Array.from(textbox.parentElement.children as HTMLCollectionOf<HTMLInputElement>)
+									.map(textbox => textbox.value)
 									.filter(value => !!value),
 								getObjectIndex(),
 							);
@@ -1208,7 +1210,7 @@ textarea
 				messageBox.classList.add("message");
 				messageBox.placeholder = submitterInfo.message.placeholder;
 				messageBox.spellcheck = true;
-				messageBox.addEventListener("keypress", (event: KeyboardEvent) => {
+				(messageBox as HTMLElement).addEventListener("keypress", event => {
 					if (event.key === "Enter" && (messageInfo.singleline || event.ctrlKey)) {
 						button.click();
 					}

--- a/src/modules/search-site.mts
+++ b/src/modules/search-site.mts
@@ -4,12 +4,10 @@
 class SearchSite {
 	// All appropriate attributes must be compared in `this.equals`
 	readonly hostname: string;
-	readonly pathname: [ string, string ];
-	readonly param: string;
+	readonly pathname: [ string, string ] | undefined;
+	readonly param: string | undefined;
 
-	constructor (args?: { urlDynamicString: string }) {
-		if (!args)
-			return;
+	constructor (args: { urlDynamicString: string }) {
 		const urlDynamic = new URL(args.urlDynamicString);
 		this.hostname = urlDynamic.hostname;
 		if (urlDynamic.pathname.includes("%s")) {
@@ -38,8 +36,8 @@ class SearchSite {
 					url.pathname.indexOf(this.pathname[0]) + this.pathname[0].length,
 					url.pathname.lastIndexOf(this.pathname[1])).split("+")
 				: null
-			: url.searchParams.has(this.param)
-				? matchOnly ? [] : (url.searchParams.get(this.param) ?? "").split(" ")
+			: url.searchParams.has(this.param ?? "")
+				? matchOnly ? [] : (url.searchParams.get(this.param ?? "") ?? "").split(" ")
 				: null;
 	}
 

--- a/src/pages/options.mts
+++ b/src/pages/options.mts
@@ -605,10 +605,10 @@ label[for]:hover
 						hues: {
 							label: "Highlight colour hue values",
 							type: PreferenceType.ARRAY_NUMBER,
-							getPreviewElement: (huesString: string) => {
+							getPreviewElement: huesString => {
 								const container = document.createElement("div");
 								container.classList.add(OptionSpecialClass.HIGHLIGHT_COLORS);
-								for (const hue of huesString.split(",").map(hueString => parseInt(hueString))) {
+								for (const hue of (huesString as string).split(",").map(hueString => parseInt(hueString))) {
 									const colorElement = document.createElement("div");
 									colorElement.style.setProperty("--hue", hue.toString());
 									container.appendChild(colorElement);

--- a/src/pages/popup.mts
+++ b/src/pages/popup.mts
@@ -32,7 +32,9 @@ const loadPopup = (() => {
 					const matchMode = Object.assign({}, termList.terms[objectIndex].matchMode) as MatchMode;
 					matchMode[mode] = checked;
 					const term = new MatchTerm(termList.terms[objectIndex].phrase, matchMode);
-					termList.terms[objectIndex] = term;
+					const terms = [ ...termList.terms ];
+					terms[objectIndex] = term;
+					termList.terms = terms;
 					Config.set(config);
 				});
 			},
@@ -413,7 +415,9 @@ const loadPopup = (() => {
 														Config.get({ termListOptions: [ "termLists" ] }).then(config => {
 															const termList = config.termListOptions.termLists[containerIndex];
 															const term = new MatchTerm(text, termList.terms[objectIndex].matchMode);
-															termList.terms[objectIndex] = term;
+															const terms = [ ...termList.terms ];
+															terms[objectIndex] = term;
+															termList.terms = terms;
 															Config.set(config);
 														});
 													},

--- a/src/paint.ts
+++ b/src/paint.ts
@@ -16,7 +16,7 @@ registerPaint("markmysearch-highlights", class {
 	) {
 		const selectorStyles = JSON.parse(properties.get("--markmysearch-styles")?.toString() || "{}") as TermSelectorStyles;
 		const boxes = JSON.parse(properties.get("--markmysearch-boxes")?.toString() || "[]") as Array<Box>;
-		boxes.forEach(box => {
+		for (const box of boxes) {
 			const style = selectorStyles[box.token];
 			if (!style) {
 				return;
@@ -24,12 +24,14 @@ registerPaint("markmysearch-highlights", class {
 			ctx.strokeStyle = `hsl(${style.hue} 100% 10% / 0.4)`;
 			ctx.strokeRect(box.x, box.y, box.width, box.height);
 			const height = box.height / Math.floor((style.cycle + 3) / 2);
-			// Special case: 1st cycle (only one with a single block of color) must begin with hue 60.
-			style.cycle = style.cycle === 0 ? -1 : style.cycle;
+			if (style.cycle === 0) {
+				// Special case: 1st cycle (only one with a single block of color) must begin with the lightness closer to 50%.
+				style.cycle = -1;
+			}
 			for (let i = 0; i <= (style.cycle + 1) / 2; i++) {
 				ctx.fillStyle = `hsl(${style.hue} 100% ${(i % 2 == style.cycle % 2) ? 98 : 60}% / 0.4)`;
 				ctx.fillRect(box.x, box.y + height*i, box.width, height);
 			}
-		});
+		}
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,12 @@
 		"declaration": true,
 		"alwaysStrict": true,
 		"strictNullChecks": true,
+		"strictBindCallApply": true,
+		"strictFunctionTypes": true,
+		"strictPropertyInitialization": true,
+		//"noImplicitAny": true,
+		"noImplicitThis": true,
+		"useUnknownInCatchVariables": true,
 		"verbatimModuleSyntax": true,
 		"paths": {
 			"/dist/*": [ "./src/*" ],


### PR DESCRIPTION
- Change (or begin changing) many long-established code conventions
- Clean up code related to highlighting, primarily to improve safety and consistency
  - Improve typing (e.g. with specific types for elements with (or possibly with) a tree cache
- Add more strict rules to tsconfig