### PR TITLE
Normalise several class bodies

### DIFF
--- a/src/modules/highlight/engine-manager.mts
+++ b/src/modules/highlight/engine-manager.mts
@@ -203,9 +203,9 @@ class EngineManager implements AbstractEngineManager {
 			);
 			return {
 				engine,
-				termCounter: new TermCounter(engine.elementFlowsMap),
-				termWalker: new TermWalker(engine.elementFlowsMap),
-				termMarker: new TermMarker(this.#termTokens, engine.elementFlowsMap),
+				termCounter: new TermCounter(engine.getElementFlowsMap()),
+				termWalker: new TermWalker(engine.getElementFlowsMap()),
+				termMarker: new TermMarker(this.#termTokens, engine.getElementFlowsMap()),
 			};
 		} case "HIGHLIGHT": {
 			const [ { HighlightEngine }, { TermCounter }, { TermWalker }, { TermMarker } ] = await Promise.all([
@@ -217,9 +217,9 @@ class EngineManager implements AbstractEngineManager {
 			const engine = new HighlightEngine(this.#termTokens, this.#termPatterns);
 			return {
 				engine,
-				termCounter: new TermCounter(engine.elementFlowsMap),
-				termWalker: new TermWalker(engine.elementFlowsMap),
-				termMarker: new TermMarker(this.#termTokens, engine.elementFlowsMap),
+				termCounter: new TermCounter(engine.getElementFlowsMap()),
+				termWalker: new TermWalker(engine.getElementFlowsMap()),
+				termMarker: new TermMarker(this.#termTokens, engine.getElementFlowsMap()),
 			};
 		}}
 	}

--- a/src/modules/highlight/engines/element.mts
+++ b/src/modules/highlight/engines/element.mts
@@ -102,10 +102,10 @@ class ElementEngine implements AbstractTreeEditEngine {
 	readonly class = "ELEMENT";
 	readonly model = "tree-edit";
 
-	readonly termTokens: TermTokens;
-	readonly termPatterns: TermPatterns;
+	readonly #termTokens: TermTokens;
+	readonly #termPatterns: TermPatterns;
 
-	readonly flowMutations: MutationObserverWrapper;
+	readonly #flowMutations: MutationObserverWrapper;
 
 	readonly terms = createContainer<ReadonlyArray<MatchTerm>>([]);
 	readonly hues = createContainer<ReadonlyArray<number>>([]);
@@ -114,10 +114,10 @@ class ElementEngine implements AbstractTreeEditEngine {
 		termTokens: TermTokens,
 		termPatterns: TermPatterns,
 	) {
-		this.termTokens = termTokens;
-		this.termPatterns = termPatterns;
+		this.#termTokens = termTokens;
+		this.#termPatterns = termPatterns;
 		const mutationObserver = this.getFlowMutationObserver();
-		this.flowMutations = {
+		this.#flowMutations = {
 			observeMutations: () => {
 				mutationObserver.observe(document.body, { subtree: true, childList: true, characterData: true });
 			},
@@ -146,8 +146,8 @@ ${HIGHLIGHT_TAG} {
 			const hue = hues[termIndex % hues.length];
 			const cycle = Math.floor(termIndex / hues.length);
 			return (`
-#${EleID.BAR} ~ body .${EleClass.FOCUS_CONTAINER} ${HIGHLIGHT_TAG}.${getTermClass(term, this.termTokens)},
-#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body ${HIGHLIGHT_TAG}.${getTermClass(term, this.termTokens)} {
+#${EleID.BAR} ~ body .${EleClass.FOCUS_CONTAINER} ${HIGHLIGHT_TAG}.${getTermClass(term, this.#termTokens)},
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body ${HIGHLIGHT_TAG}.${getTermClass(term, this.#termTokens)} {
 	background: ${this.getTermBackgroundStyle(`hsl(${hue} 100% 60% / 0.4)`, `hsl(${hue} 100% 88% / 0.4)`, cycle)};
 	box-shadow: 0 0 0 1px hsl(${hue} 100% 20% / 0.35);
 }`
@@ -163,16 +163,16 @@ ${HIGHLIGHT_TAG} {
 		termsToPurge: ReadonlyArray<MatchTerm>,
 		hues: ReadonlyArray<number>,
 	) {
-		this.flowMutations.unobserveMutations();
+		this.#flowMutations.unobserveMutations();
 		this.undoHighlights(termsToPurge);
 		this.terms.assign(terms);
 		this.hues.assign(hues);
 		this.generateTermHighlightsUnderNode(termsToHighlight, document.body);
-		this.flowMutations.observeMutations();
+		this.#flowMutations.observeMutations();
 	}
 
 	endHighlighting () {
-		this.flowMutations.unobserveMutations();
+		this.#flowMutations.unobserveMutations();
 		this.undoHighlights();
 	}
 
@@ -186,7 +186,7 @@ ${HIGHLIGHT_TAG} {
 		if (terms && !terms.length) {
 			return; // Optimization for removing 0 terms
 		}
-		const classNames = terms?.map(term => getTermClass(term, this.termTokens));
+		const classNames = terms?.map(term => getTermClass(term, this.#termTokens));
 		const highlights = Array.from(root.querySelectorAll(
 			classNames ? `${HIGHLIGHT_TAG}.${classNames.join(`, ${HIGHLIGHT_TAG}.`)}` : HIGHLIGHT_TAG
 		)).reverse();
@@ -210,7 +210,7 @@ ${HIGHLIGHT_TAG} {
 
 	getHighlightedElementsForTerms (terms: ReadonlyArray<MatchTerm>): Iterable<HTMLElement> {
 		return terms.length === 0 ? [] : document.body.querySelectorAll(terms
-			.map(term => `${HIGHLIGHT_TAG}.${getTermClass(term, this.termTokens)}`)
+			.map(term => `${HIGHLIGHT_TAG}.${getTermClass(term, this.#termTokens)}`)
 			.join(", ")
 		);
 	}
@@ -264,7 +264,7 @@ ${HIGHLIGHT_TAG} {
 			// insert: Highlight Element
 			const textHighlightNode = document.createTextNode(text.substring(start, end));
 			const highlight = document.createElement(HIGHLIGHT_TAG);
-			highlight.classList.add(getTermClass(term, this.termTokens));
+			highlight.classList.add(getTermClass(term, this.#termTokens));
 			highlight.appendChild(textHighlightNode);
 			parent.insertBefore(highlight, node);
 			const textHighlightNodeItem = nodeItems.insertItemAfter(nodeItemPrevious, textHighlightNode);
@@ -294,7 +294,7 @@ ${HIGHLIGHT_TAG} {
 			const parent = textAfterNode.parentNode as Node;
 			const textEndNode = document.createTextNode(text.substring(start, end));
 			const highlight = document.createElement(HIGHLIGHT_TAG);
-			highlight.classList.add(getTermClass(term, this.termTokens));
+			highlight.classList.add(getTermClass(term, this.#termTokens));
 			highlight.appendChild(textEndNode);
 			textAfterNode.textContent = text.substring(end);
 			parent.insertBefore(highlight, textAfterNode);
@@ -320,7 +320,7 @@ ${HIGHLIGHT_TAG} {
 				let nodeItem = nodeItems.first!;
 				let textStart = 0;
 				let textEnd = nodeItem.value.length;
-				for (const match of textFlow.matchAll(this.termPatterns.get(term))) {
+				for (const match of textFlow.matchAll(this.#termPatterns.get(term))) {
 					let highlightStart = match.index!;
 					const highlightEnd = highlightStart + match[0].length;
 					while (textEnd <= highlightStart) {

--- a/src/modules/highlight/models/tree-cache.mts
+++ b/src/modules/highlight/models/tree-cache.mts
@@ -1,11 +1,13 @@
+import type { Flow } from "/dist/modules/highlight/models/tree-cache/flow-monitor.mjs";
 import type { AbstractEngine } from "/dist/modules/highlight/engine.mjs";
+import type { AllReadonly } from "/dist/modules/common.mjs";
 
 type Model = "tree-cache"
 
 interface AbstractTreeCacheEngine extends AbstractEngine {
 	readonly model: Model
+
+	getElementFlowsMap: () => AllReadonly<Map<HTMLElement, Array<Flow>>>;
 }
 
-export type {
-	AbstractTreeCacheEngine,
-};
+export type { AbstractTreeCacheEngine };

--- a/src/modules/highlight/models/tree-cache/term-markers/term-marker.mts
+++ b/src/modules/highlight/models/tree-cache/term-markers/term-marker.mts
@@ -6,11 +6,14 @@ import { EleID, getElementYRelative, getTermClass, type AllReadonly } from "/dis
 type Flow = BaseFlow<false>
 
 class TermMarker implements AbstractTermMarker {
-	#termTokens: TermTokens;
+	readonly #termTokens: TermTokens;
 
-	#elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>;
+	readonly #elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>;
 
-	constructor (termTokens: TermTokens, elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>) {
+	constructor (
+		termTokens: TermTokens,
+		elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>,
+	) {
 		this.#termTokens = termTokens;
 		this.#elementFlowsMap = elementFlowsMap;
 	}

--- a/src/modules/highlight/models/tree-cache/term-walkers/term-walker.mts
+++ b/src/modules/highlight/models/tree-cache/term-walkers/term-walker.mts
@@ -7,7 +7,7 @@ import type { AllReadonly } from "/dist/modules/common.mjs";
 type Flow = BaseFlow<false>
 
 class TermWalker implements AbstractTermWalker {
-	#elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>;
+	readonly #elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>;
 
 	constructor (elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>) {
 		this.#elementFlowsMap = elementFlowsMap;

--- a/src/modules/highlight/models/tree-edit/term-counters/term-counter.mts
+++ b/src/modules/highlight/models/tree-edit/term-counters/term-counter.mts
@@ -3,7 +3,7 @@ import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import { getTermClass } from "/dist/modules/common.mjs";
 
 class TermCounter implements AbstractTermCounter {
-	#termTokens: TermTokens;
+	readonly #termTokens: TermTokens;
 	
 	constructor (termTokens: TermTokens) {
 		this.#termTokens = termTokens;

--- a/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
+++ b/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
@@ -8,7 +8,7 @@ import {
 } from "/dist/modules/common.mjs";
 
 class TermMarker implements AbstractTermMarker {
-	#termTokens: TermTokens;
+	readonly #termTokens: TermTokens;
 	
 	constructor (termTokens: TermTokens) {
 		this.#termTokens = termTokens;

--- a/src/modules/highlight/models/tree-edit/term-walkers/term-walker.mts
+++ b/src/modules/highlight/models/tree-edit/term-walkers/term-walker.mts
@@ -6,7 +6,7 @@ import { getTermClass } from "/dist/modules/common.mjs";
 import { EleID, EleClass, getNodeFinal, isVisible, elementsPurgeClass } from "/dist/modules/common.mjs";
 
 class TermWalker implements AbstractTermWalker {
-	#termTokens: TermTokens;
+	readonly #termTokens: TermTokens;
 	
 	constructor (termTokens: TermTokens) {
 		this.#termTokens = termTokens;


### PR DESCRIPTION
- More consistently use private and readonly attributes (where appropriate)
- Move attributes to the top
- Move getters and listener-adders to the bottom