### PR TITLE
Update Config "get" syntax

### DIFF
--- a/src/modules/page/build.mts
+++ b/src/modules/page/build.mts
@@ -486,11 +486,11 @@ export const loadPage = (() => {
 		};
 		style.textContent =
 `:root {
-	--hue: ${Config.getDefault({ theme: [ "hue" ] }).theme.hue};
-	--contrast: ${Config.getDefault({ theme: [ "contrast" ] }).theme.contrast};
-	--lightness: ${Config.getDefault({ theme: [ "lightness" ] }).theme.lightness};
-	--saturation: ${Config.getDefault({ theme: [ "saturation" ] }).theme.saturation};
-	--font-scale: ${Config.getDefault({ theme: [ "fontScale" ] }).theme.fontScale};
+	--hue: ${Config.getDefault({ theme: { hue: true } }).theme.hue};
+	--contrast: ${Config.getDefault({ theme: { contrast: true } }).theme.contrast};
+	--lightness: ${Config.getDefault({ theme: { lightness: true } }).theme.lightness};
+	--saturation: ${Config.getDefault({ theme: { saturation: true } }).theme.saturation};
+	--font-scale: ${Config.getDefault({ theme: { fontScale: true } }).theme.fontScale};
 }
 body
 	{ height: 100vh; margin: 0; box-sizing: border-box; border: 2px solid ${color.border.frame}; overflow: hidden;

--- a/src/pages/options-new.mts
+++ b/src/pages/options-new.mts
@@ -3,8 +3,10 @@ import {
 	type Page, loadPage, pageReload, pageThemeUpdate,
 	isWindowInFrame, sendProblemReport, getOrderedShortcut, forInput,
 } from "/dist/modules/page/build.mjs";
-import type { StoreImmediate, StoreList, ConfigValues, ConfigKey } from "/dist/modules/privileged/storage.mjs";
-import { StoreType, StoreListInterface, Config } from "/dist/modules/privileged/storage.mjs";
+import type {
+	StoreImmediate, StoreList, StoreListInterface, ConfigValues, ConfigKey,
+} from "/dist/modules/privileged/storage.mjs";
+import { StoreType, Config } from "/dist/modules/privileged/storage.mjs";
 import { compatibility } from "/dist/modules/common.mjs";
 
 const getControlOptionTemp = <ConfigK extends ConfigKey>(
@@ -188,12 +190,12 @@ const loadOptionsNew = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										Config.get({ urlFilters: [ "noPageModify" ] }).then(config => //
+										Config.get({ urlFilters: { noPageModify: true } }).then(config => //
 											config.urlFilters.noPageModify.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										Config.get({ urlFilters: [ "noPageModify" ] }).then(config => {
+										Config.get({ urlFilters: { noPageModify: true } }).then(config => {
 											config.urlFilters.noPageModify = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -458,12 +460,12 @@ const loadOptionsNew = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										Config.get({ urlFilters: [ "nonSearch" ] }).then(config => //
+										Config.get({ urlFilters: { nonSearch: true } }).then(config => //
 											config.urlFilters.nonSearch.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										Config.get({ urlFilters: [ "nonSearch" ] }).then(config => {
+										Config.get({ urlFilters: { nonSearch: true } }).then(config => {
 											config.urlFilters.nonSearch = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {

--- a/src/pages/options.mts
+++ b/src/pages/options.mts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 //import { isWindowInFrame } from "/dist/modules/page/build.mjs";
-import type { StoreImmediate, StoreList, ConfigValues, ConfigKey } from "/dist/modules/privileged/storage.mjs";
-import { StoreType, StoreListInterface, Config } from "/dist/modules/privileged/storage.mjs";
+import type {
+	StoreImmediate, StoreList, StoreListInterface, ConfigValues, ConfigKey,
+} from "/dist/modules/privileged/storage.mjs";
+import { StoreType, Config } from "/dist/modules/privileged/storage.mjs";
 import { compatibility, getIdSequential } from "/dist/modules/common.mjs";
 
 const isWindowInFrame = () => (

--- a/src/pages/popup.mts
+++ b/src/pages/popup.mts
@@ -23,11 +23,11 @@ const loadPopup = (() => {
 		},
 		input: {
 			onLoad: async (setChecked, objectIndex, containerIndex) => {
-				const config = await Config.get({ termListOptions: [ "termLists" ] });
+				const config = await Config.get({ termListOptions: { termLists: true } });
 				setChecked(config.termListOptions.termLists[containerIndex].terms[objectIndex].matchMode[mode]);
 			},
 			onChange: (checked, objectIndex, containerIndex) => {
-				Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+				Config.get({ termListOptions: { termLists: true } }).then(config => {
 					const termList = config.termListOptions.termLists[containerIndex];
 					const matchMode = Object.assign({}, termList.terms[objectIndex].matchMode) as MatchMode;
 					matchMode[mode] = checked;
@@ -87,11 +87,11 @@ const loadPopup = (() => {
 							input: {
 								getType: () => "checkbox",
 								onLoad: async setChecked => {
-									const config = await Config.get({ autoFindOptions: [ "enabled" ] });
+									const config = await Config.get({ autoFindOptions: { enabled: true } });
 									setChecked(config.autoFindOptions.enabled);
 								},
 								onChange: async checked => {
-									const config = await Config.get({ autoFindOptions: [ "enabled" ] });
+									const config = await Config.get({ autoFindOptions: { enabled: true } });
 									config.autoFindOptions.enabled = checked;
 									await Config.set(config);
 								},
@@ -105,11 +105,11 @@ const loadPopup = (() => {
 							input: {
 								getType: () => "checkbox",
 								onLoad: async setChecked => {
-									const config = await Config.get({ researchInstanceOptions: [ "restoreLastInTab" ] });
+									const config = await Config.get({ researchInstanceOptions: { restoreLastInTab: true } });
 									setChecked(config.researchInstanceOptions.restoreLastInTab);
 								},
 								onChange: async checked => {
-									const config = await Config.get({ researchInstanceOptions: [ "restoreLastInTab" ] });
+									const config = await Config.get({ researchInstanceOptions: { restoreLastInTab: true } });
 									config.researchInstanceOptions.restoreLastInTab = checked;
 									await Config.set(config);
 								},
@@ -140,7 +140,7 @@ const loadPopup = (() => {
 											if (tab.id === undefined) {
 												return;
 											}
-											const config = await Config.get({ researchInstanceOptions: [ "restoreLastInTab" ] });
+											const config = await Config.get({ researchInstanceOptions: { restoreLastInTab: true } });
 											const researchInstance = bank.researchInstances[tab.id];
 											if (researchInstance && config.researchInstanceOptions.restoreLastInTab) {
 												researchInstance.enabled = true;
@@ -258,12 +258,12 @@ const loadPopup = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										Config.get({ urlFilters: [ "noPageModify" ] }).then(config => //
+										Config.get({ urlFilters: { noPageModify: true } }).then(config => //
 											config.urlFilters.noPageModify.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										Config.get({ urlFilters: [ "noPageModify" ] }).then(config => {
+										Config.get({ urlFilters: { noPageModify: true } }).then(config => {
 											config.urlFilters.noPageModify = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -292,12 +292,12 @@ const loadPopup = (() => {
 								className: "url-input",
 								list: {
 									getArray: () =>
-										Config.get({ urlFilters: [ "nonSearch" ] }).then(config => //
+										Config.get({ urlFilters: { nonSearch: true } }).then(config => //
 											config.urlFilters.nonSearch.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: array =>
-										Config.get({ urlFilters: [ "nonSearch" ] }).then(config => {
+										Config.get({ urlFilters: { nonSearch: true } }).then(config => {
 											config.urlFilters.nonSearch = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -332,12 +332,12 @@ const loadPopup = (() => {
 							className: "temp-class",
 							list: {
 								getLength: () =>
-									Config.get({ termListOptions: [ "termLists" ] }).then(config =>
+									Config.get({ termListOptions: { termLists: true } }).then(config =>
 										config.termListOptions.termLists.length
 									)
 								,
 								pushWithName: name =>
-									Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+									Config.get({ termListOptions: { termLists: true } }).then(config => {
 										config.termListOptions.termLists.push({
 											name,
 											terms: [],
@@ -347,7 +347,7 @@ const loadPopup = (() => {
 									})
 								,
 								removeAt: index =>
-									Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+									Config.get({ termListOptions: { termLists: true } }).then(config => {
 										config.termListOptions.termLists.splice(index, 1);
 										Config.set(config);
 									})
@@ -356,12 +356,12 @@ const loadPopup = (() => {
 							label: {
 								text: "",
 								getText: index =>
-									Config.get({ termListOptions: [ "termLists" ] }).then(config =>
+									Config.get({ termListOptions: { termLists: true } }).then(config =>
 										config.termListOptions.termLists[index] ? config.termListOptions.termLists[index].name : ""
 									)
 								,
 								setText: (text, index) =>
-									Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+									Config.get({ termListOptions: { termLists: true } }).then(config => {
 										config.termListOptions.termLists[index].name = text;
 										Config.set(config);
 									})
@@ -374,12 +374,12 @@ const loadPopup = (() => {
 								className: "term",
 								list: {
 									getArray: index =>
-										Config.get({ termListOptions: [ "termLists" ] }).then(config =>
+										Config.get({ termListOptions: { termLists: true } }).then(config =>
 											config.termListOptions.termLists[index].terms as unknown as Array<Record<string, unknown>>
 										)
 									,
 									setArray: (array, index) =>
-										Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+										Config.get({ termListOptions: { termLists: true } }).then(config => {
 											config.termListOptions.termLists[index].terms =
 												array as unknown as typeof config["termListOptions"]["termLists"][number]["terms"];
 											Config.set(config);
@@ -407,12 +407,12 @@ const loadPopup = (() => {
 													placeholder: "keyword",
 													spellcheck: false,
 													onLoad: async (setText, objectIndex, containerIndex) => {
-														const config = await Config.get({ termListOptions: [ "termLists" ] });
+														const config = await Config.get({ termListOptions: { termLists: true } });
 														setText(config.termListOptions.termLists[containerIndex].terms[objectIndex]
 															? config.termListOptions.termLists[containerIndex].terms[objectIndex].phrase : "");
 													},
 													onChange: (text, objectIndex, containerIndex) => {
-														Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+														Config.get({ termListOptions: { termLists: true } }).then(config => {
 															const termList = config.termListOptions.termLists[containerIndex];
 															const term = new MatchTerm(text, termList.terms[objectIndex].matchMode);
 															const terms = [ ...termList.terms ];
@@ -441,12 +441,12 @@ const loadPopup = (() => {
 								className: "temp-class",
 								list: {
 									getArray: index =>
-										Config.get({ termListOptions: [ "termLists" ] }).then(config => //
+										Config.get({ termListOptions: { termLists: true } }).then(config => //
 											config.termListOptions.termLists[index].urlFilter.map(({ hostname, pathname }) => hostname + pathname) //
 										)
 									,
 									setArray: (array, index) =>
-										Config.get({ termListOptions: [ "termLists" ] }).then(config => {
+										Config.get({ termListOptions: { termLists: true } }).then(config => {
 											config.termListOptions.termLists[index].urlFilter = array.map(value => {
 												const pathnameStart = value.includes("/") ? value.indexOf("/") : value.length;
 												return {
@@ -469,7 +469,7 @@ const loadPopup = (() => {
 										if (tab.id === undefined) {
 											return;
 										}
-										const config = await Config.get({ termListOptions: [ "termLists" ] });
+										const config = await Config.get({ termListOptions: { termLists: true } });
 										const bank = await Bank.get([ "researchInstances" ]);
 										const researchInstance = bank.researchInstances[tab.id];
 										if (researchInstance) {

--- a/src/pages/startpage.mts
+++ b/src/pages/startpage.mts
@@ -74,11 +74,11 @@ You can always activate ${Manifest.getName()} by opening its popup (from the 'ex
 							input: {
 								getType: () => "checkbox",
 								onLoad: async setChecked => {
-									const config = await Config.get({ autoFindOptions: [ "enabled" ] });
+									const config = await Config.get({ autoFindOptions: { enabled: true } });
 									setChecked(config.autoFindOptions.enabled);
 								},
 								onChange: async checked => {
-									const config = await Config.get({ autoFindOptions: [ "enabled" ] });
+									const config = await Config.get({ autoFindOptions: { enabled: true } });
 									config.autoFindOptions.enabled = checked;
 									await Config.set(config);
 								},


### PR DESCRIPTION
- Change syntax of Config (storage) "get" API, to accept an object where each value is either another object (representing one level down) or simply `true` to represent everything under the current key
  - This new syntax allows extending to an any-level (as opposed to 2-level) Config system
- Update every call to Config "get" API to use the new syntax