### PR TITLE
Rename FlowMonitor->FlowTracker

### DIFF
--- a/src/modules/highlight/models/tree-cache.mts
+++ b/src/modules/highlight/models/tree-cache.mts
@@ -1,4 +1,4 @@
-import type { Flow } from "/dist/modules/highlight/models/tree-cache/flow-monitor.mjs";
+import type { Flow } from "/dist/modules/highlight/models/tree-cache/flow-tracker.mjs";
 import type { AbstractEngine } from "/dist/modules/highlight/engine.mjs";
 import type { AllReadonly } from "/dist/modules/common.mjs";
 

--- a/src/modules/highlight/models/tree-cache/flow-tracker.mts
+++ b/src/modules/highlight/models/tree-cache/flow-tracker.mts
@@ -15,7 +15,7 @@ type Span = BaseSpan<true>
  * - determining "flows" of text and matching within them, producing highlighting "boxes" information;
  * - maintaining a cache of [TODO]
  */
-interface AbstractFlowMonitor extends FlowMutationObserver {
+interface AbstractFlowTracker extends FlowMutationObserver {
 	readonly getElementFlowsMap: () => AllReadonly<Map<HTMLElement, Array<Flow>>>
 
 	/** Sets the listener for gain of highlight spans in an unhighlighted element. */
@@ -82,5 +82,5 @@ interface AbstractFlowMonitor extends FlowMutationObserver {
 
 export type {
 	Flow, Span,
-	AbstractFlowMonitor,
+	AbstractFlowTracker,
 };

--- a/src/modules/highlight/models/tree-cache/flow-trackers/flow-tracker.mts
+++ b/src/modules/highlight/models/tree-cache/flow-trackers/flow-tracker.mts
@@ -1,10 +1,10 @@
-import type { Flow, Span, AbstractFlowMonitor } from "/dist/modules/highlight/models/tree-cache/flow-monitor.mjs";
+import type { Flow, Span, AbstractFlowTracker } from "/dist/modules/highlight/models/tree-cache/flow-tracker.mjs";
 import { highlightTags } from "/dist/modules/highlight/highlight-tags.mjs";
 import { matchInTextFlow } from "/dist/modules/highlight/matcher.mjs";
 import { MatchTerm, type TermPatterns } from "/dist/modules/match-term.mjs";
 import type { RContainer, AllReadonly } from "/dist/modules/common.mjs";
 
-class FlowMonitor implements AbstractFlowMonitor {
+class FlowTracker implements AbstractFlowTracker {
 	readonly #termPatterns: TermPatterns;
 
 	/**
@@ -331,4 +331,4 @@ class FlowMonitor implements AbstractFlowMonitor {
 	}
 }
 
-export { FlowMonitor };
+export { FlowTracker };


### PR DESCRIPTION
- Rename all instances of the name "FlowMonitor" to "FlowTracker", as this better indicates what its function is