### PR TITLE
Make modules handle their elements (incl. styles)

### DIFF
--- a/src/content.mts
+++ b/src/content.mts
@@ -128,17 +128,6 @@ const startHighlighting = (
 	);
 };
 
-/**
- * Inserts a uniquely identified CSS stylesheet to perform all extension styling.
- */
-const styleElementsInsert = () => {
-	if (!document.getElementById(EleID.DRAW_CONTAINER)) {
-		const container = document.createElement("div");
-		container.id = EleID.DRAW_CONTAINER;
-		document.body.insertAdjacentElement("afterend", container);
-	}
-};
-
 // TODO decompose this horrible generator function
 /**
  * Returns a generator function to consume individual command objects and produce their desired effect.
@@ -254,7 +243,7 @@ interface TermAppender<Async = true> {
 			}
 			const termsOld: ReadonlyArray<MatchTerm> = [ ...terms ];
 			terms = termsNew;
-			styleManager.updateStyle(terms, termTokens, hues, highlighter);
+			styleManager.updateStyle(terms, termTokens, hues);
 			updateToolbar(termsOld, terms, null, getToolbar(), commands);
 			// Give the interface a chance to redraw before performing highlighting.
 			setTimeout(() => {
@@ -270,7 +259,7 @@ interface TermAppender<Async = true> {
 			} else {
 				terms = terms.slice(0, termIndex).concat(terms.slice(termIndex + 1));
 			}
-			styleManager.updateStyle(terms, termTokens, hues, highlighter);
+			styleManager.updateStyle(terms, termTokens, hues);
 			updateToolbar(termsOld, terms, { term, termIndex }, getToolbar(), commands);
 			// Give the interface a chance to redraw before performing highlighting.
 			setTimeout(() => {
@@ -280,7 +269,7 @@ interface TermAppender<Async = true> {
 		appendTerm: term => {
 			const termsOld: ReadonlyArray<MatchTerm> = [ ...terms ];
 			terms = terms.concat(term);
-			styleManager.updateStyle(terms, termTokens, hues, highlighter);
+			styleManager.updateStyle(terms, termTokens, hues);
 			updateToolbar(termsOld, terms, { term, termIndex: termsOld.length }, getToolbar(), commands);
 			// Give the interface a chance to redraw before performing highlighting.
 			setTimeout(() => {
@@ -351,7 +340,6 @@ interface TermAppender<Async = true> {
 		if (queuingPromise) {
 			await queuingPromise;
 		}
-		styleElementsInsert();
 		if (message.highlighter !== undefined) {
 			highlighter.removeEngine();
 			highlighter.signalPaintEngineMethod(message.highlighter.paintEngine.method);
@@ -441,7 +429,8 @@ interface TermAppender<Async = true> {
 			if (messageQueue.length === 1) {
 				sendBackgroundMessage({ initializationGet: true }).then(initMessage => {
 					if (!initMessage) {
-						assert(false, "not initialized, so highlighting remains inactive", "no init response was received");
+						assert(false, "not initialized, so highlighting remains inactive",
+							"no init response was received");
 						return;
 					}
 					const initialize = () => {

--- a/src/modules/common.mts
+++ b/src/modules/common.mts
@@ -117,14 +117,11 @@ const compatibility = new Compatibility();
 const [ Z_INDEX_MIN, Z_INDEX_MAX ] = [ -(2**31), 2**31 - 1 ];
 
 enum EleID {
-	STYLE_PAINT = "markmysearch--style-paint",
-	STYLE_PAINT_SPECIAL = "markmysearch--style-paint-special",
 	BAR = "markmysearch--bar",
 	MARKER_GUTTER = "markmysearch--markers",
 	DRAW_CONTAINER = "markmysearch--draw-container",
-	DRAW_ELEMENT = "markmysearch--draw",
-	ELEMENT_CONTAINER_SPECIAL = "markmysearch--element-container-special",
-	INPUT = "markmysearch--input",
+	DRAW_ELEMENT = "markmysearch--draw-",
+	INPUT = "markmysearch--input-",
 }
 
 enum EleClass {

--- a/src/modules/highlight/engine-manager.mts
+++ b/src/modules/highlight/engine-manager.mts
@@ -67,18 +67,6 @@ class EngineManager implements AbstractEngineManager {
 		this.#updateTermStatus = updateTermStatus;
 	}
 
-	readonly getCSS = {
-		misc: (): string => (
-			this.#engineData?.engine.getCSS.misc() ?? ""
-		),
-		termHighlights: (): string => (
-			this.#engineData?.engine.getCSS.termHighlights() ?? ""
-		),
-		termHighlight: (terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>, termIndex: number): string => (
-			this.#engineData?.engine.getCSS.termHighlight(terms, hues, termIndex) ?? ""
-		),
-	};
-
 	getTermBackgroundStyle (colorA: string, colorB: string, cycle: number): string {
 		return this.#engineData?.engine.getTermBackgroundStyle(colorA, colorB, cycle) ?? "";
 	}
@@ -127,7 +115,7 @@ class EngineManager implements AbstractEngineManager {
 	async setEngine (preference: Engine) {
 		const highlighting = this.#highlighting;
 		if (highlighting && this.#engineData) {
-			this.#engineData.engine.endHighlighting();
+			this.#engineData.engine.deactivate();
 		}
 		this.#engineData = await this.constructAndLinkEngineData(compatibility.highlighting.engineToUse(preference));
 	}
@@ -232,7 +220,7 @@ class EngineManager implements AbstractEngineManager {
 
 	removeEngine () {
 		if (this.#highlighting && this.#engineData) {
-			this.#engineData.engine.endHighlighting();
+			this.#engineData.engine.deactivate();
 		}
 		this.#engineData = null;
 	}

--- a/src/modules/highlight/engine.mts
+++ b/src/modules/highlight/engine.mts
@@ -16,6 +16,8 @@ interface AbstractEngine extends Highlighter {
 	readonly terms: RContainer<ReadonlyArray<MatchTerm>>;
 	readonly hues: RContainer<ReadonlyArray<number>>;
 
+	readonly deactivate: () => void
+
 	readonly addHighlightingUpdatedListener: (listener: Generator) => void
 
 	readonly getHighlightedElements: () => Iterable<HTMLElement>
@@ -24,20 +26,8 @@ interface AbstractEngine extends Highlighter {
 interface Highlighter extends HighlighterCSSInterface, HighlightingInterface {}
 
 interface HighlighterCSSInterface {
-	readonly getCSS: EngineCSS
-
 	readonly getTermBackgroundStyle: (colorA: string, colorB: string, cycle: number) => string
 }
-
-type EngineCSS = Readonly<{
-	misc: () => string
-	termHighlights: () => string
-	termHighlight: (
-		terms: ReadonlyArray<MatchTerm>,
-		hues: ReadonlyArray<number>,
-		termIndex: number,
-	) => string
-}>
 
 interface HighlightingInterface {
 	/**
@@ -59,6 +49,6 @@ interface HighlightingInterface {
 export type {
 	AbstractEngine,
 	Highlighter,
-	HighlighterCSSInterface, EngineCSS,
+	HighlighterCSSInterface,
 	HighlightingInterface,
 };

--- a/src/modules/highlight/engines/paint/method.mts
+++ b/src/modules/highlight/engines/paint/method.mts
@@ -6,13 +6,21 @@
 
 import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
 import type { Highlightables } from "/dist/modules/highlight/engines/paint/highlightables.mjs";
-import type { EngineCSS } from "/dist/modules/highlight/engine.mjs";
 import type { MatchTerm } from "/dist/modules/match-term.mjs";
 
 interface AbstractMethod {
-	readonly highlightables?: Highlightables
+	readonly deactivate: () => void
 
-	readonly getCSS: EngineCSS
+	readonly startHighlighting: (
+		terms: ReadonlyArray<MatchTerm>,
+		termsToHighlight: ReadonlyArray<MatchTerm>,
+		termsToPurge: ReadonlyArray<MatchTerm>,
+		hues: ReadonlyArray<number>,
+	) => void
+
+	readonly endHighlighting: () => void
+
+	readonly highlightables?: Highlightables
 
 	/**
 	 * Gets a CSS rule to style all elements as per the enabled PAINT variant.

--- a/src/modules/highlight/engines/paint/methods/paint.mts
+++ b/src/modules/highlight/engines/paint/methods/paint.mts
@@ -7,8 +7,9 @@
 import type { AbstractMethod } from "/dist/modules/highlight/engines/paint/method.mjs";
 import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
 import type { Highlightables } from "/dist/modules/highlight/engines/paint/highlightables.mjs";
-import type { EngineCSS } from "/dist/modules/highlight/engine.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
+import { StyleManager } from "/dist/modules/style-manager.mjs";
+import { HTMLStylesheet } from "/dist/modules/stylesheets/html.mjs";
 import { EleID, EleClass } from "/dist/modules/common.mjs";
 
 type TermSelectorStyles = Record<string, {
@@ -19,6 +20,8 @@ type TermSelectorStyles = Record<string, {
 class PaintMethod implements AbstractMethod {
 	readonly #termTokens: TermTokens;
 
+	readonly #styleManager = new StyleManager(new HTMLStylesheet(document.head));
+
 	static #paintModuleAdded = false;
 
 	constructor (termTokens: TermTokens) {
@@ -27,6 +30,47 @@ class PaintMethod implements AbstractMethod {
 			CSS.paintWorklet?.addModule(chrome.runtime.getURL("/dist/paint.js"));
 			PaintMethod.#paintModuleAdded = true;
 		}
+	}
+
+	deactivate () {
+		this.endHighlighting();
+		this.#styleManager.deactivate();
+	}
+
+	startHighlighting (
+		terms: ReadonlyArray<MatchTerm>,
+		termsToHighlight: ReadonlyArray<MatchTerm>,
+		termsToPurge: ReadonlyArray<MatchTerm>,
+		hues: ReadonlyArray<number>,
+	) {
+		this.#styleManager.setStyle(this.getTermsCSS(terms, hues));
+	}
+
+	endHighlighting () {}
+
+	getTermsCSS (terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) {
+		const styles: TermSelectorStyles = {};
+		for (let i = 0; i < terms.length; i++) {
+			styles[this.#termTokens.get(terms[i])] = {
+				hue: hues[i % hues.length],
+				cycle: Math.floor(i / hues.length),
+			};
+		}
+		return (`
+#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body [markmysearch-h_id] {
+	& [markmysearch-h_beneath] {
+		background-color: transparent !important;
+	}
+	& {
+		background-image: paint(markmysearch-highlights) !important;
+		--markmysearch-styles: ${JSON.stringify(styles)};
+	}
+	& > :not([markmysearch-h_id]) {
+		--markmysearch-styles: unset;
+		--markmysearch-boxes: unset;
+	}
+}`
+		);
 	}
 
 	readonly highlightables: Highlightables = {
@@ -46,35 +90,6 @@ class PaintMethod implements AbstractMethod {
 				}
 			}
 			return ancestor;
-		},
-	};
-
-	readonly getCSS: EngineCSS = {
-		misc: () => "",
-		termHighlights: () => "",
-		termHighlight: (terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) => {
-			const styles: TermSelectorStyles = {};
-			for (let i = 0; i < terms.length; i++) {
-				styles[this.#termTokens.get(terms[i])] = {
-					hue: hues[i % hues.length],
-					cycle: Math.floor(i / hues.length),
-				};
-			}
-			return (`
-#${EleID.BAR}.${EleClass.HIGHLIGHTS_SHOWN} ~ body [markmysearch-h_id] {
-& [markmysearch-h_beneath] {
-	background-color: transparent;
-}
-& {
-	background-image: paint(markmysearch-highlights);
-	--markmysearch-styles: ${JSON.stringify(styles)};
-}
-& > :not([markmysearch-h_id]) {
-	--markmysearch-styles: unset;
-	--markmysearch-boxes: unset;
-}
-}`
-			);
 		},
 	};
 

--- a/src/modules/highlight/engines/paint/methods/url.mts
+++ b/src/modules/highlight/engines/paint/methods/url.mts
@@ -6,7 +6,6 @@
 
 import type { AbstractMethod } from "/dist/modules/highlight/engines/paint/method.mjs";
 import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
-import type { EngineCSS } from "/dist/modules/highlight/engine.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import { EleID, EleClass } from "/dist/modules/common.mjs";
 
@@ -17,11 +16,11 @@ class UrlMethod implements AbstractMethod {
 		this.#termTokens = termTokens;
 	}
 
-	readonly getCSS: EngineCSS = {
-		misc: () => "",
-		termHighlights: () => "",
-		termHighlight: () => "",
-	};
+	deactivate () {}
+
+	startHighlighting () {}
+
+	endHighlighting () {}
 
 	constructHighlightStyleRule (
 		highlightingId: number,

--- a/src/modules/highlight/models/tree-cache/term-markers/term-marker.mts
+++ b/src/modules/highlight/models/tree-cache/term-markers/term-marker.mts
@@ -16,12 +16,21 @@ class TermMarker implements AbstractTermMarker {
 
 	readonly #elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>;
 
+	readonly #scrollGutter: HTMLElement;
+
 	constructor (
 		termTokens: TermTokens,
 		elementFlowsMap: AllReadonly<Map<HTMLElement, Array<Flow>>>,
 	) {
 		this.#termTokens = termTokens;
 		this.#elementFlowsMap = elementFlowsMap;
+		this.#scrollGutter = document.createElement("div");
+		this.#scrollGutter.id = EleID.MARKER_GUTTER;
+		document.body.insertAdjacentElement("afterend", this.#scrollGutter);
+	}
+
+	deactivate () {
+		this.#scrollGutter.remove();
 	}
 
 	insert (
@@ -30,7 +39,6 @@ class TermMarker implements AbstractTermMarker {
 		highlightedElements: Iterable<HTMLElement>,
 	) {
 		const termsSet = new Set(terms);
-		const gutter = document.getElementById(EleID.MARKER_GUTTER)!;
 		let markersHtml = "";
 		for (const element of highlightedElements) if (this.#elementFlowsMap.has(element)) {
 			const highlightedTerms = new Set((this.#elementFlowsMap.get(element) ?? []).flatMap(flow =>
@@ -44,8 +52,8 @@ class TermMarker implements AbstractTermMarker {
 				}" top="${yRelative}" style="top: ${yRelative * 100}%; padding-left: ${i * 5}px; z-index: ${i * -1}"></div>`)
 				.join("");
 		}
-		gutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
-		gutter.innerHTML = markersHtml;
+		this.#scrollGutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
+		this.#scrollGutter.innerHTML = markersHtml;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
+++ b/src/modules/highlight/models/tree-edit/term-markers/term-marker.mts
@@ -8,16 +8,24 @@ import type { AbstractTermMarker } from "/dist/modules/highlight/term-marker.mjs
 import { getContainerBlock } from "/dist/modules/highlight/container-blocks.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
 import {
-	EleID, EleClass,
-	getElementYRelative, elementsPurgeClass,
+	EleID, EleClass, getElementYRelative, elementsPurgeClass,
 	getTermClass, getTermClassToken,
 } from "/dist/modules/common.mjs";
 
 class TermMarker implements AbstractTermMarker {
 	readonly #termTokens: TermTokens;
+
+	readonly #scrollGutter: HTMLElement;
 	
 	constructor (termTokens: TermTokens) {
 		this.#termTokens = termTokens;
+		this.#scrollGutter = document.createElement("div");
+		this.#scrollGutter.id = EleID.MARKER_GUTTER;
+		document.body.insertAdjacentElement("afterend", this.#scrollGutter);
+	}
+
+	deactivate () {
+		this.#scrollGutter.remove();
 	}
 
 	insert (
@@ -26,7 +34,6 @@ class TermMarker implements AbstractTermMarker {
 		highlightedElements: Iterable<HTMLElement>,
 	) {
 		const regexMatchTermSelector = new RegExp(`\\b${EleClass.TERM}(?:-\\w+)+\\b`);
-		const gutter = document.getElementById(EleID.MARKER_GUTTER)!;
 		const containersInfo: Array<{
 			container: HTMLElement
 			termsAdded: Set<string>
@@ -56,16 +63,15 @@ class TermMarker implements AbstractTermMarker {
 			}
 			markersHtml += `<div class="${className}" top="${yRelative}" style="${markerCss}"></div>`;
 		}
-		gutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
-		gutter.innerHTML = markersHtml;
+		this.#scrollGutter.replaceChildren(); // Removes children, since inner HTML replacement does not for some reason
+		this.#scrollGutter.innerHTML = markersHtml;
 	}
 
 	raise (term: MatchTerm | null, container: HTMLElement) {
-		const scrollMarkerGutter = document.getElementById(EleID.MARKER_GUTTER)!;
-		elementsPurgeClass(EleClass.FOCUS, scrollMarkerGutter);
+		elementsPurgeClass(EleClass.FOCUS, this.#scrollGutter);
 		[6, 5, 4, 3, 2].some(precisionFactor => {
 			const precision = 10**precisionFactor;
-			const scrollMarker = scrollMarkerGutter.querySelector(
+			const scrollMarker = this.#scrollGutter.querySelector(
 				`${term ? `.${getTermClass(term, this.#termTokens)}` : ""}[top^="${
 					Math.trunc(getElementYRelative(container) * precision) / precision
 				}"]`

--- a/src/modules/highlight/special-engines/paint.mts
+++ b/src/modules/highlight/special-engines/paint.mts
@@ -9,6 +9,8 @@ import type { Box } from "/dist/modules/highlight/engines/paint.mjs";
 import { UrlMethod } from "/dist/modules/highlight/engines/paint/methods/url.mjs";
 import { type BaseFlow, type BaseSpan, matchInText } from "/dist/modules/highlight/matcher.mjs";
 import type { MatchTerm, TermTokens, TermPatterns } from "/dist/modules/match-term.mjs";
+import { StyleManager } from "/dist/modules/style-manager.mjs";
+import { HTMLStylesheet } from "/dist/modules/stylesheets/html.mjs";
 import { EleID, EleClass, getElementTagsSet } from "/dist/modules/common.mjs";
 
 type Flow = BaseFlow<false>
@@ -22,65 +24,58 @@ type HighlightContext = keyof typeof contextCSS
 type StyleRulesInfo = Record<HighlightContext, string>
 
 class PaintSpecialEngine implements AbstractSpecialEngine {
-	readonly termTokens: TermTokens;
-	readonly termPatterns: TermPatterns;
+	readonly #termTokens: TermTokens;
+	readonly #termPatterns: TermPatterns;
 
-	readonly method: UrlMethod;
-	terms: ReadonlyArray<MatchTerm> = [];
-	hues: ReadonlyArray<number> = [];
-	readonly styleRules: StyleRulesInfo = { hovered: "", focused: "" };
+	readonly #method: UrlMethod;
+	readonly #styleRules: StyleRulesInfo = { hovered: "", focused: "" };
 
-	readonly elementsInfo = new Map<HTMLElement, {
-		properties: Record<string, { get: () => unknown, set: (value: unknown) => unknown }>
-	}>();
+	//readonly #elementsInfo = new Map<HTMLElement, {
+	//	properties: Record<string, { get: () => unknown, set: (value: unknown) => unknown }>
+	//}>();
+
+	readonly #styleManager = new StyleManager(new HTMLStylesheet(document.head));
+	readonly #elementContainer: HTMLElement;
+
+	#terms: ReadonlyArray<MatchTerm> = [];
+	#hues: ReadonlyArray<number> = [];
 
 	constructor (termTokens: TermTokens, termPatterns: TermPatterns) {
-		this.termTokens = termTokens;
-		this.termPatterns = termPatterns;
-		this.method = new UrlMethod(termTokens);
+		this.#termTokens = termTokens;
+		this.#termPatterns = termPatterns;
+		this.#method = new UrlMethod(termTokens);
+		this.#elementContainer = document.createElement("div");
+		document.body.insertAdjacentElement("afterend", this.#elementContainer);
+	}
+
+	deactivate () {
+		this.endHighlighting();
+		this.#styleManager.deactivate();
+		this.#elementContainer.remove();
 	}
 
 	startHighlighting (terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) {
 		// Clean up.
 		this.endHighlighting();
 		// MAIN
-		this.terms = terms;
-		this.hues = hues;
-		this.insertHelperElements();
+		this.#terms = terms;
+		this.#hues = hues;
 		window.addEventListener("focusin", this.onFocusIn);
 		window.addEventListener("pointerover", this.onHover);
 		window.addEventListener("input", this.onInput);
 	}
 
 	endHighlighting () {
-		this.terms = [];
+		this.#terms = [];
 		window.removeEventListener("focusin", this.onFocusIn);
 		window.removeEventListener("pointerover", this.onHover);
 		window.removeEventListener("input", this.onInput);
-		this.removeHelperElements();
 	}
 
 	handledTags: Array<keyof HTMLElementTagNameMap> = [ "input", "textarea" ];
 	handledTagSelector = this.handledTags.join(", ");
 	handledTagSet = getElementTagsSet(this.handledTags); // Handle <select> elements in future?
 	handles = (element: HTMLElement) => this.handledTagSet.has(element.tagName);
-
-	insertHelperElements () {
-		const style = document.createElement("style");
-		style.id = EleID.STYLE_PAINT_SPECIAL;
-		document.head.appendChild(style);
-		const elementContainer = document.createElement("div");
-		elementContainer.id = EleID.ELEMENT_CONTAINER_SPECIAL;
-		document.body.insertAdjacentElement("afterend", elementContainer);
-	}
-
-	removeHelperElements () {
-		for (const element of document.querySelectorAll(
-			`#${EleID.STYLE_PAINT_SPECIAL}, #${EleID.ELEMENT_CONTAINER_SPECIAL}`,
-		)) {
-			element.remove();
-		}
-	}
 
 	getFlow (terms: ReadonlyArray<MatchTerm>, input: HTMLInputElement) {
 		// TODO is this method needed? why not use a common matching function?
@@ -89,7 +84,7 @@ class PaintSpecialEngine implements AbstractSpecialEngine {
 			spans: [],
 		};
 		for (const term of terms) {
-			for (const match of flow.text.matchAll(this.termPatterns.get(term))) if (match.index !== undefined) {
+			for (const match of flow.text.matchAll(this.#termPatterns.get(term))) if (match.index !== undefined) {
 				flow.spans.push({
 					term,
 					start: match.index,
@@ -103,7 +98,7 @@ class PaintSpecialEngine implements AbstractSpecialEngine {
 		//console.log("focus in", event.target, event.relatedTarget);
 		if (event.target instanceof HTMLElement) {
 			if (this.handles(event.target)) {
-				this.highlight("focused", this.terms, this.hues);
+				this.highlight("focused", this.#terms, this.#hues);
 			}
 		} else if (event.relatedTarget instanceof HTMLElement) {
 			if (this.handles(event.relatedTarget)) {
@@ -116,7 +111,7 @@ class PaintSpecialEngine implements AbstractSpecialEngine {
 		//console.log("mouse enter", event.target, event.relatedTarget);
 		if (event.target instanceof HTMLElement) {
 			if (this.handles(event.target)) {
-				this.highlight("hovered", this.terms, this.hues);
+				this.highlight("hovered", this.#terms, this.#hues);
 			}
 		} else if (event.relatedTarget instanceof HTMLElement) {
 			if (this.handles(event.relatedTarget)) {
@@ -129,7 +124,7 @@ class PaintSpecialEngine implements AbstractSpecialEngine {
 		if (!(event.target instanceof HTMLElement) || !this.handles(event.target)) {
 			return;
 		}
-		this.highlight("focused", this.terms, this.hues);
+		this.highlight("focused", this.#terms, this.#hues);
 	};
 
 	highlight (highlightCtx: HighlightContext, terms: ReadonlyArray<MatchTerm>, hues: ReadonlyArray<number>) {
@@ -163,30 +158,26 @@ class PaintSpecialEngine implements AbstractSpecialEngine {
 		if (!terms.length) {
 			return "url()";
 		}
-		const boxes = matchInText(terms, this.termPatterns, text).map((span): Box => {
+		const boxes = matchInText(terms, this.#termPatterns, text).map((span): Box => {
 			return {
-				token: this.termTokens.get(span.term),
+				token: this.#termTokens.get(span.term),
 				x: span.start * 10,
 				y: 0,
 				width: (span.end - span.start) * 10,
 				height: 20,
 			};
 		});
-		return this.method.constructHighlightStyleRuleUrl(boxes, terms, hues);
+		return this.#method.constructHighlightStyleRuleUrl(boxes, terms, hues);
 	}
 
 	styleUpdate (styleRules: Partial<StyleRulesInfo>) {
-		const style = document.getElementById(EleID.STYLE_PAINT_SPECIAL) as HTMLStyleElement;
 		for (const highlightContext of Object.keys(contextCSS) as Array<HighlightContext>) {
 			const rule = styleRules[highlightContext];
 			if (rule !== undefined) {
-				this.styleRules[highlightContext] = rule;
+				this.#styleRules[highlightContext] = rule;
 			}
 		}
-		const styleContent = Object.values(this.styleRules).join("\n");
-		if (styleContent !== style.textContent) {
-			style.textContent = styleContent;
-		}
+		this.#styleManager.setStyle(Object.values(this.#styleRules).join("\n"));
 	}
 }
 

--- a/src/modules/interface/toolbar/common.mts
+++ b/src/modules/interface/toolbar/common.mts
@@ -99,7 +99,7 @@ const applyMatchModeToClassList = (
 	classListToggle(EleClass.MATCH_DIACRITICS, matchMode.diacritics);
 };
 
-const getInputIdSequential = () => CommonEleID.INPUT + "-" + getIdSequential.next().value.toString();
+const getInputIdSequential = () => CommonEleID.INPUT + getIdSequential.next().value.toString();
 
 const getControlClass = (controlName: ControlButtonName) => EleClass.CONTROL + "-" + controlName;
 

--- a/src/modules/interface/toolbars/toolbar.mts
+++ b/src/modules/interface/toolbars/toolbar.mts
@@ -45,8 +45,6 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 	readonly #controls: Readonly<Record<ControlButtonName, Control>>;
 	readonly #termControls: Array<TermReplaceControl> = [];
 	readonly #termAppendControl: TermAppendControl;
-	// TODO why is the toolbar in charge of the scroll gutter??
-	readonly #scrollGutter: HTMLElement;
 
 	readonly #selectionReturn = new ToolbarSelectionReturnManager();
 	#indicatedClassToken: string | null = null;
@@ -210,8 +208,6 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 			),
 		};
 		this.replaceTerms(terms, commands);
-		this.#scrollGutter = document.createElement("div");
-		this.#scrollGutter.id = CommonEleID.MARKER_GUTTER;
 	}
 
 	getTermAbstractControls (): Array<TermAbstractControl> {
@@ -502,7 +498,6 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 
 	insertAdjacentTo (element: HTMLElement, position: InsertPosition) {
 		element.insertAdjacentElement(position, this.#barContainer);
-		element.insertAdjacentElement(position, this.#scrollGutter);
 	}
 
 	remove () {
@@ -511,7 +506,6 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 			document.activeElement.blur();
 		}
 		this.#barContainer.remove();
-		this.#scrollGutter.remove();
 	}
 }
 

--- a/src/modules/style.mts
+++ b/src/modules/style.mts
@@ -7,7 +7,6 @@
 import { StyleManager } from "/dist/modules/style-manager.mjs";
 import { HTMLStylesheet } from "/dist/modules/stylesheets/html.mjs";
 import type { MatchTerm, TermTokens } from "/dist/modules/match-term.mjs";
-import type { HighlighterCSSInterface } from "/dist/modules/highlight/engine.mjs";
 import { Z_INDEX_MAX, EleID, EleClass, AtRuleID, getTermClass } from "/dist/modules/common.mjs";
 
 class Style {
@@ -17,7 +16,6 @@ class Style {
 		terms: ReadonlyArray<MatchTerm>,
 		termTokens: TermTokens,
 		hues: ReadonlyArray<number>,
-		highlighter: HighlighterCSSInterface,
 	) {
 		/** Prevents websites from taking precedence by applying !important to every rule. */
 		const makeImportant = (styleText: string) => (
@@ -53,11 +51,7 @@ class Style {
 .${EleClass.FOCUS_CONTAINER} {
 	animation: ${AtRuleID.FLASH} 1s;
 }
-${highlighter.getCSS.termHighlights()}
 `) + (`
-
-${highlighter.getCSS.misc()}
-
 /* || Transitions */
 
 @keyframes ${AtRuleID.MARKER_ON} {
@@ -75,10 +69,6 @@ ${highlighter.getCSS.misc()}
 			const term = terms[i];
 			const hue = hues[i % hues.length];
 			style += makeImportant(`
-/* || Term Highlight */
-
-${highlighter.getCSS.termHighlight(terms, hues, i)}
-
 /* || Term Scroll Markers */
 
 #${EleID.MARKER_GUTTER} .${getTermClass(term, termTokens)} {


### PR DESCRIPTION
- Make modules responsible for their elements, including style elements
  - Use StyleManager to replace all directly-used style elements
  - Move most styling out of the general-purpose style module