### PR TITLE
Update broken paths to content.mts's entrypoint

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -31,7 +31,7 @@
 	"content_scripts": [
 		{
 			"matches": [ "*://*/*" ],
-			"js": [ "/dist/content-entry.js" ],
+			"js": [ "/dist/entrypoints/content.js" ],
 			"run_at": "document_start"
 		}
 	],
@@ -55,6 +55,7 @@
 			"resources": [
 				"/icons/*.svg",
 				"/dist/content.mjs",
+				"/dist/entrypoints/content.js",
 				"/dist/modules/*.mjs"
 			],
 			"matches": [ "*://*/*" ]

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -35,7 +35,7 @@
 	"content_scripts": [
 		{
 			"matches": [ "*://*/*" ],
-			"js": [ "/dist/content-entry.js" ],
+			"js": [ "/dist/entrypoints/content.js" ],
 			"run_at": "document_start"
 		}
 	],
@@ -56,6 +56,7 @@
 			"resources": [
 				"/icons/*.svg",
 				"/dist/content.mjs",
+				"/dist/entrypoints/content.js",
 				"/dist/modules/*.mjs"
 			],
 			"matches": [ "*://*/*" ]

--- a/src/background.mts
+++ b/src/background.mts
@@ -237,7 +237,7 @@ const injectIntoTabs = () => new Promise<void>(resolve => {
 		pendingCount++;
 		await chrome.scripting.executeScript({
 			target: { tabId: tab.id as number },
-			files: [ "/dist/content-entry.js" ],
+			files: [ "/dist/entrypoints/content.js" ],
 		}).catch(() => chrome.runtime.lastError); // Read `lastError` to suppress injection errors.
 		pendingCount--;
 		if (pendingCount === 0) resolve();


### PR DESCRIPTION
The issue was caused by the entrypoint being cached at its old index.