### PR TITLE
Insert toolbar even when there are no terms

### DIFF
--- a/src/content.mts
+++ b/src/content.mts
@@ -387,6 +387,8 @@ interface TermAppender<Async = true> {
 			getToolbarOrNull()?.remove();
 		}
 		if (message.terms) {
+			// Ensure the toolbar is set up.
+			getToolbar().insertAdjacentTo(document.body, "beforebegin");
 			// TODO make sure same MatchTerm objects are used for terms which are equivalent
 			termSetterInternal.setTerms(message.terms);
 		}

--- a/src/modules/interface/toolbar.mts
+++ b/src/modules/interface/toolbar.mts
@@ -73,6 +73,7 @@ class Toolbar implements AbstractToolbar, ToolbarTermControlInterface, ToolbarCo
 		this.#highlighter = highlighter;
 		this.#barContainer = document.createElement("div");
 		this.#barContainer.id = CommonEleID.BAR;
+		this.#barContainer.style.cssText = "all: revert !important;";
 		const shadowRoot = this.#barContainer.attachShadow({
 			mode: "closed",
 			delegatesFocus: false,


### PR DESCRIPTION
- Fix bug where empty insertion of toolbar did not happen
- Add "all: revert !important" CSS rule to toolbar container