### PR TITLE
Fix new term controls not recognising Shift+click

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1199,8 +1199,8 @@ const insertTermControl = (terms: MatchTerms, idx: number, command: string, comm
 	controlContent.classList.add(getSel(ElementClass.CONTROL_CONTENT));
 	controlContent.tabIndex = -1;
 	controlContent.textContent = term.phrase;
-	controlContent.onclick = () => { // Hack: event handler property used so that the listener is not duplicated.
-		focusOnTermJump(controlsInfo, highlightTags, false, term);
+	controlContent.onclick = event => { // Hack: event handler property used so that the listener is not duplicated.
+		focusOnTermJump(controlsInfo, highlightTags, event.shiftKey, term);
 	};
 	controlContent.addEventListener("mouseover", () => { // FIXME this is not screenreader friendly.
 		updateTermTooltip(term, controlsInfo);


### PR DESCRIPTION
- Shift+click on a term control (content) is supposed to "jump" in reverse for that term, instead of forwards. When newly inserted, this did not happen.
- The duplicated code problem which caused this is fixed in 2.0.