### PR TITLE
Remove browser_style references from manifest.json

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -41,8 +41,7 @@
 	],
 
 	"options_ui": {
-		"page": "/pages/options.html",
-		"browser_style": true
+		"page": "/pages/options.html"
 	},
 
 	"action": {

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -52,8 +52,7 @@
 	],
 
 	"options_ui": {
-		"page": "/pages/options.html",
-		"browser_style": true
+		"page": "/pages/options.html"
 	},
 
 	"action": {


### PR DESCRIPTION
- browser_style has been deprecated and is not supported in manifest V3