### PR TITLE
Add EUPL-1.2-or-later licence notice to files

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -1,3 +1,8 @@
+<!--
+This file is part of Mark My Search.
+Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+Licensed under the EUPL-1.2-or-later.
+-->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -1,3 +1,8 @@
+<!--
+This file is part of Mark My Search.
+Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+Licensed under the EUPL-1.2-or-later.
+-->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/pages/sendoff.html
+++ b/pages/sendoff.html
@@ -1,3 +1,8 @@
+<!--
+This file is part of Mark My Search.
+Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+Licensed under the EUPL-1.2-or-later.
+-->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/pages/startpage.html
+++ b/pages/startpage.html
@@ -1,3 +1,8 @@
+<!--
+This file is part of Mark My Search.
+Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+Licensed under the EUPL-1.2-or-later.
+-->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 if (this.importScripts) {
 	// Required for service workers, whereas event pages use declarative imports.
 	this.importScripts(

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 type BrowserCommands = Array<chrome.commands.Command>
 type HighlightTags = {
 	reject: ReadonlySet<string>,

--- a/src/include/page-build.ts
+++ b/src/include/page-build.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 type PageInteractionObjectRowInfo = {
 	className: string
 	key: string

--- a/src/include/pattern-diacritic.ts
+++ b/src/include/pattern-diacritic.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 /**
  * Given any string containing common variants of alphanumeric characters,
  * creates a regex string which will match the same series of letters in any of their diacritic forms, leaving unrecognised characters.

--- a/src/include/pattern-stem.ts
+++ b/src/include/pattern-stem.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 /**
  * Gets prefix and suffix regex strings for any word.
  * Only yields meaningful results for English words which fit standard word form patterns.

--- a/src/include/storage.ts
+++ b/src/include/storage.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 chrome.storage = useChromeAPI() ? chrome.storage : browser.storage as typeof chrome.storage;
 chrome.storage.session ??= chrome.storage.local;
 

--- a/src/include/util-privileged.ts
+++ b/src/include/util-privileged.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 chrome.tabs.query = useChromeAPI() ? chrome.tabs.query : browser.tabs.query as typeof chrome.tabs.query;
 chrome.tabs.sendMessage = useChromeAPI()
 	? chrome.tabs.sendMessage

--- a/src/include/utility.ts
+++ b/src/include/utility.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 type MatchTerms = Array<MatchTerm>
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/pages/options.ts
+++ b/src/pages/options.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 type OptionsInfo = Array<{
 	label: string
 	options: Partial<Record<keyof StorageSyncValues, {

--- a/src/pages/popup-build.ts
+++ b/src/pages/popup-build.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 /**
  * Loads the popup content into the page.
  * This presents the user with common options and actions (usually those needed while navigating), to be placed in a popup.

--- a/src/pages/sendoff-build.ts
+++ b/src/pages/sendoff-build.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 /**
  * Loads the sendoff page content into the page.
  * This presents the user with an offboarding form with detail, for use when the user has uninstalled the extension.

--- a/src/pages/startpage-build.ts
+++ b/src/pages/startpage-build.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 /**
  * Loads the startpage content into the page.
  * This presents the user with expandable onboarding information and functions, for use when the user has installed the extension.

--- a/src/paint.ts
+++ b/src/paint.ts
@@ -1,3 +1,9 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
 type PaintWorkletType = {
 	devicePixelRatio: number
 	registerPaint: (name: string, classRef: unknown) => void


### PR DESCRIPTION
- Add EUPL-1.2-or-later licence notice header to source files as a comment
  - Include ator-dev and Mark My Search contributors as authors