### PR TITLE
Convert scripts into ES modules

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -9,11 +9,6 @@ Licensed under the EUPL-1.2-or-later.
 		<meta charset="utf-8">
 	</head>
 	<body>
-		<script src="/dist/include/utility.js"></script>
-		<script src="/dist/include/pattern-stem.js"></script>
-		<script src="/dist/include/pattern-diacritic.js"></script>
-		<script src="/dist/include/util-privileged.js"></script>
-		<script src="/dist/include/storage.js"></script>
-		<script src="/dist/pages/options.js"></script>
+		<script src="/dist/pages/options.mjs" type="module"></script>
 	</body>
 </html>

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -9,13 +9,6 @@ Licensed under the EUPL-1.2-or-later.
 		<meta charset="utf-8">
 	</head>
 	<body>
-		<script src="/dist/include/utility.js"></script>
-		<script src="/dist/include/pattern-stem.js"></script>
-		<script src="/dist/include/pattern-diacritic.js"></script>
-		<script src="/dist/include/util-privileged.js"></script>
-		<script src="/dist/include/storage.js"></script>
-		<script src="/lib/email.min.js"></script>
-		<script src="/dist/include/page-build.js"></script>
-		<script src="/dist/pages/popup-build.js"></script>
+		<script src="/dist/pages/popup-build.mjs" type="module"></script>
 	</body>
 </html>

--- a/pages/sendoff.html
+++ b/pages/sendoff.html
@@ -9,13 +9,6 @@ Licensed under the EUPL-1.2-or-later.
 		<meta charset="utf-8">
 	</head>
 	<body>
-		<script src="/dist/include/utility.js"></script>
-		<script src="/dist/include/pattern-stem.js"></script>
-		<script src="/dist/include/pattern-diacritic.js"></script>
-		<script src="/dist/include/util-privileged.js"></script>
-		<script src="/dist/include/storage.js"></script>
-		<script src="/lib/email.min.js"></script>
-		<script src="/dist/include/page-build.js"></script>
-		<script src="/dist/pages/sendoff-build.js"></script>
+		<script src="/dist/pages/sendoff-build.mjs" type="module"></script>
 	</body>
 </html>

--- a/pages/startpage.html
+++ b/pages/startpage.html
@@ -9,14 +9,7 @@ Licensed under the EUPL-1.2-or-later.
 		<meta charset="utf-8">
 	</head>
 	<body>
-		<script src="/dist/include/utility.js"></script>
-		<script src="/dist/include/pattern-stem.js"></script>
-		<script src="/dist/include/pattern-diacritic.js"></script>
-		<script src="/dist/include/util-privileged.js"></script>
-		<script src="/dist/include/storage.js"></script>
-		<script src="/lib/email.min.js"></script>
-		<script src="/dist/include/page-build.js"></script>
-		<script src="/dist/pages/startpage-build.js"></script>
-		<script src="/dist/content.js"></script>
+		<script src="/dist/pages/startpage-build.mjs" type="module"></script>
+		<script src="/dist/content.mjs" type="module"></script>
 	</body>
 </html>

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -24,18 +24,14 @@
 	],
 
 	"background": {
-		"service_worker": "/dist/background.js"
+		"type": "module",
+		"service_worker": "/dist/background.mjs"
 	},
 
 	"content_scripts": [
 		{
 			"matches": [ "*://*/*" ],
-			"js": [
-				"/dist/include/utility.js",
-				"/dist/include/pattern-stem.js",
-				"/dist/include/pattern-diacritic.js",
-				"/dist/content.js"
-			],
+			"js": [ "/dist/entrypoints/content.js" ],
 			"run_at": "document_start"
 		}
 	],
@@ -56,16 +52,10 @@
 	"web_accessible_resources": [
 		{
 			"resources": [
-				"/dist/paint.js",
-				"/icons/arrow.svg",
-				"/icons/close.svg",
-				"/icons/search.svg",
-				"/icons/show.svg",
-				"/icons/refresh.svg",
-				"/icons/create.svg",
-				"/icons/delete.svg",
-				"/icons/edit.svg",
-				"/icons/reveal.svg"
+				"/icons/*.svg",
+				"/dist/content.mjs",
+				"/dist/entrypoints/content.js",
+				"/dist/modules/*.mjs"
 			],
 			"matches": [ "*://*/*" ]
 		}

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -28,25 +28,14 @@
 	],
 
 	"background": {
-		"scripts": [
-			"/dist/include/utility.js",
-			"/dist/include/pattern-stem.js",
-			"/dist/include/pattern-diacritic.js",
-			"/dist/include/util-privileged.js",
-			"/dist/include/storage.js",
-			"/dist/background.js"
-		]
+		"type": "module",
+		"scripts": [ "/dist/background.mjs" ]
 	},
 
 	"content_scripts": [
 		{
 			"matches": [ "*://*/*" ],
-			"js": [
-				"/dist/include/utility.js",
-				"/dist/include/pattern-stem.js",
-				"/dist/include/pattern-diacritic.js",
-				"/dist/content.js"
-			],
+			"js": [ "/dist/entrypoints/content.js" ],
 			"run_at": "document_start"
 		}
 	],
@@ -64,16 +53,10 @@
 	"web_accessible_resources": [
 		{
 			"resources": [
-				"/dist/paint.js",
-				"/icons/arrow.svg",
-				"/icons/close.svg",
-				"/icons/search.svg",
-				"/icons/show.svg",
-				"/icons/refresh.svg",
-				"/icons/create.svg",
-				"/icons/delete.svg",
-				"/icons/edit.svg",
-				"/icons/reveal.svg"
+				"/icons/*.svg",
+				"/dist/content.mjs",
+				"/dist/entrypoints/content.js",
+				"/dist/modules/*.mjs"
 			],
 			"matches": [ "*://*/*" ]
 		}

--- a/src/content.mts
+++ b/src/content.mts
@@ -4,6 +4,20 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
+import type {
+	CommandInfo,
+	HighlightDetailsRequest, HighlightMessage, HighlightMessageResponse,
+	MatchMode, MatchTerms,
+} from "/dist/modules/utility.mjs";
+import {
+	assert,
+	CommandType,
+	itemsMatch,
+	MatchTerm,
+	messageSendBackground, parseCommand, termEquals,
+} from "/dist/modules/utility.mjs";
+import type { StorageSyncValues, StorageSync } from "/dist/modules/storage.mjs";
+
 type BrowserCommands = Array<chrome.commands.Command>
 type HighlightTags = {
 	reject: ReadonlySet<string>,
@@ -558,7 +572,6 @@ const focusOnScrollMarkerPaint = (term: MatchTerm | undefined, container: HTMLEl
 	// Depends on scroll markers refreshed Paint implementation (TODO)
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const focusOnScrollMarker = (term: MatchTerm | undefined, container: HTMLElement, controlsInfo: ControlsInfo) =>
 	focusOnScrollMarkerClassic(term, container)
 ;
@@ -3183,7 +3196,7 @@ const getTermsFromSelection = () => {
 
 	return () => {
 		if (!paintUsePaintingFallback) {
-			(CSS["paintWorklet"] as PaintWorkletType).addModule(chrome.runtime.getURL("/dist/paint.js"));
+			CSS["paintWorklet"].addModule(chrome.runtime.getURL("/dist/paint.js"));
 		}
 		// Can't remove controls because a script may be left behind from the last install, and start producing unhandled errors. FIXME
 		//controlsRemove();
@@ -3388,3 +3401,5 @@ const getTermsFromSelection = () => {
 		messageHandleHighlightGlobal = messageHandleHighlight;
 	};
 })()();
+
+export type { TermSelectorStyles, HighlightBox };

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -1,0 +1,7 @@
+/*
+ * This file is part of Mark My Search.
+ * Copyright © 2021-present ‘ator-dev’, Mark My Search contributors.
+ * Licensed under the EUPL-1.2-or-later.
+ */
+
+import(chrome.runtime.getURL("/dist/content.mjs"));

--- a/src/modules/page-build.mts
+++ b/src/modules/page-build.mts
@@ -4,19 +4,23 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
-type PageInteractionObjectRowInfo = {
+import type { MatchTerm } from "/dist/modules/utility.mjs";
+import { getIdSequential, getName } from "/dist/modules/utility.mjs";
+import { StorageSession, storageGet } from "/dist/modules/storage.mjs";
+
+export type PageInteractionObjectRowInfo = {
 	className: string
 	key: string
 	label?: PageInteractionInfo["label"]
 	textbox?: PageInteractionInfo["textbox"]
 	checkbox?: PageInteractionInfo["checkbox"]
 }
-type PageInteractionObjectColumnInfo = {
+export type PageInteractionObjectColumnInfo = {
 	className: string
 	rows: Array<PageInteractionObjectRowInfo>
 }
-type PageInteractionSubmitterLoad = (setEnabled: (enabled: boolean) => void) => void
-type PageInteractionSubmitterInfo = {
+export type PageInteractionSubmitterLoad = (setEnabled: (enabled: boolean) => void) => void
+export type PageInteractionSubmitterInfo = {
 	text: string
 	id?: string
 	onLoad?: PageInteractionSubmitterLoad
@@ -36,14 +40,14 @@ type PageInteractionSubmitterInfo = {
 	}
 	alerts?: Record<PageAlertType, PageAlertInfo>
 }
-type PageInteractionCheckboxLoad = (setChecked: (checked: boolean) => void, objectIndex: number, containerIndex: number) => Promise<void>
-type PageInteractionCheckboxToggle = (checked: boolean, objectIndex: number, containerIndex: number) => void
-type PageInteractionCheckboxInfo = {
+export type PageInteractionCheckboxLoad = (setChecked: (checked: boolean) => void, objectIndex: number, containerIndex: number) => Promise<void>
+export type PageInteractionCheckboxToggle = (checked: boolean, objectIndex: number, containerIndex: number) => void
+export type PageInteractionCheckboxInfo = {
 	autoId?: string
 	onLoad?: PageInteractionCheckboxLoad
 	onToggle?: PageInteractionCheckboxToggle
 }
-type PageInteractionInfo = {
+export type PageInteractionInfo = {
 	className: string
 	list?: {
 		getLength: () => Promise<number>
@@ -94,36 +98,36 @@ type PageInteractionInfo = {
 		text: string
 	}
 }
-type PageSectionInfo = {
+export type PageSectionInfo = {
 	title?: {
 		text: string
 		expands?: boolean
 	}
 	interactions: Array<PageInteractionInfo>
 }
-type PagePanelInfo = {
+export type PagePanelInfo = {
 	className: string
 	name: {
 		text: string
 	}
 	sections: Array<PageSectionInfo>
 }
-type PageAlertInfo = {
+export type PageAlertInfo = {
 	text: string
 	timeout?: number
 }
-type FormField = {
+export type FormField = {
 	question: string
 	response: string
 }
 
-enum PageAlertType {
+export enum PageAlertType {
 	SUCCESS = "success",
 	FAILURE = "failure",
 	PENDING = "pending",
 }
 
-//enum PageButtonClass {
+//export enum PageButtonClass {
 //	TOGGLE = "toggle",
 //	ENABLED = "enabled",
 //}
@@ -135,7 +139,7 @@ enum PageAlertType {
  * @param details Custom template field entries.
  * @param key The API key to use.
  */
-const sendEmail: (
+export const sendEmail: (
 	service: string,
 	template: string,
 	details: {
@@ -172,8 +176,7 @@ const sendEmail: (
  * Sends a problem report message to a dedicated inbox.
  * @param userMessage An optional message string to send as a comment.
 	*/
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const sendProblemReport = async (userMessage = "", formFields: Array<FormField>) => {
+export const sendProblemReport = async (userMessage = "", formFields: Array<FormField>) => {
 	const [ tab ] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 	const session = await storageGet("session", [ StorageSession.RESEARCH_INSTANCES ]);
 	const phrases = session.researchInstances[tab.id as number]
@@ -199,15 +202,14 @@ const sendProblemReport = async (userMessage = "", formFields: Array<FormField>)
 
 // TODO document functions
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const pageInsertWarning = (container: HTMLElement, text: string) => {
+export const pageInsertWarning = (container: HTMLElement, text: string) => {
 	const warning = document.createElement("div");
 	warning.classList.add("warning");
 	warning.textContent = text;
 	container.appendChild(warning);
 };
 
-const pageFocusScrollContainer = () =>
+export const pageFocusScrollContainer = () =>
 	(document.querySelector(".container-panel") as HTMLElement).focus()
 ;
 
@@ -217,8 +219,7 @@ const pageFocusScrollContainer = () =>
  * @param additionalStyleText 
  * @param shiftModifierIsRequired 
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const loadPage = (() => {
+export const loadPage = (() => {
 	/**
 	 * Fills and inserts a CSS stylesheet element to style the page.
 	 */
@@ -828,7 +829,7 @@ textarea
 			}
 			container.appendChild(button);
 			let getMessageText = () => "";
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+			// @typescript-eslint/no-empty-function
 			let allowInputs = (allowed = true) => {};
 			button.addEventListener("click", () => {
 				button.disabled = true;
@@ -1131,7 +1132,7 @@ textarea
 	};
 
 	return (panelsInfo: Array<PagePanelInfo>, additionalStyleText = "", shiftModifierIsRequired = true) => {
-		chrome.tabs.query = useChromeAPI()
+		chrome.tabs.query = !globalThis.browser
 			? chrome.tabs.query
 			: browser.tabs.query as typeof chrome.tabs.query;
 		fillAndInsertStylesheet(additionalStyleText);

--- a/src/modules/paint-worklet.mts
+++ b/src/modules/paint-worklet.mts
@@ -4,13 +4,14 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
-type PaintWorkletType = {
+import type { TermSelectorStyles, HighlightBox } from "/dist/content.mjs";
+
+type PaintWorkletGlobalScope = {
 	devicePixelRatio: number
 	registerPaint: (name: string, classRef: unknown) => void
-	addModule: (moduleURL: string, options?: { credentials: "omit" | "same-origin" | "include" }) => void
 }
 
-(globalThis as unknown as PaintWorkletType).registerPaint("markmysearch-highlights", class {
+(globalThis as unknown as PaintWorkletGlobalScope).registerPaint("markmysearch-highlights", class {
 	static get inputProperties () {
 		return [
 			"--markmysearch-styles",

--- a/src/modules/pattern-diacritic.mts
+++ b/src/modules/pattern-diacritic.mts
@@ -10,8 +10,7 @@
  * @param chars A sequence of characters.
  * @returns A regex string which matches accented forms of the letters.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const getDiacriticsMatchingPatternString: (chars: string) => string = (() => {
+export const getDiacriticsMatchingPatternString: (chars: string) => string = (() => {
 	/**
 	 * Gets the groups of characters to be considered equal (including diacritic forms) in regex notation.
 	 * @returns An array of regex OR groups, each corresponding to an alphanumeric character's lowercase and uppercase forms.

--- a/src/modules/pattern-stem.mts
+++ b/src/modules/pattern-stem.mts
@@ -10,8 +10,7 @@
  * @param word A word.
  * @returns A 2-element array containing the prefix and suffix determined to best fit the word and its forms.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const getWordPatternStrings = (() => { // TODO maybe rename as inflection finder?
+export const getWordPatternStrings = (() => { // TODO maybe rename as inflection finder?
 	/**
 	 * Reverses the characters in a string.
 	 * @param chars A string.

--- a/src/modules/storage.mts
+++ b/src/modules/storage.mts
@@ -4,20 +4,24 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
-chrome.storage = useChromeAPI() ? chrome.storage : browser.storage as typeof chrome.storage;
+import type { MatchTerms, MatchMode } from "/dist/modules/utility.mjs";
+import { MatchTerm } from "/dist/modules/utility.mjs";
+import { Engine } from "/dist/modules/util-privileged.mjs";
+
+chrome.storage = !globalThis.browser ? chrome.storage : browser.storage as typeof chrome.storage;
 chrome.storage.session ??= chrome.storage.local;
 
-type ResearchInstances = Record<number, ResearchInstance>
-type Engines = Record<string, Engine>
-type StorageSessionValues = {
+export type ResearchInstances = Record<number, ResearchInstance>
+export type Engines = Record<string, Engine>
+export type StorageSessionValues = {
 	[StorageSession.RESEARCH_INSTANCES]: ResearchInstances
 	[StorageSession.ENGINES]: Engines
 }
-type StorageLocalValues = {
+export type StorageLocalValues = {
 	[StorageLocal.ENABLED]: boolean
 	[StorageLocal.PERSIST_RESEARCH_INSTANCES]: boolean
 }
-type StorageSyncValues = {
+export type StorageSyncValues = {
 	[StorageSync.AUTO_FIND_OPTIONS]: {
 		stoplist: Array<string>
 		searchParams: Array<string>
@@ -59,41 +63,41 @@ type StorageSyncValues = {
 	}
 	[StorageSync.TERM_LISTS]: Array<TermList>
 }
-type URLFilter = Array<{
+export type URLFilter = Array<{
 	hostname: string,
 	pathname: string,
 }>
-type TermList = {
+export type TermList = {
 	name: string
 	terms: Array<MatchTerm>
 	urlFilter: URLFilter
 }
 
-type StorageAreaName = "session" | "local" | "sync"
+export type StorageAreaName = "session" | "local" | "sync"
 
-type StorageArea<Area extends StorageAreaName> =
+export type StorageArea<Area extends StorageAreaName> =
 	Area extends "session" ? StorageSession :
 	Area extends "local" ? StorageLocal :
 	Area extends "sync" ? StorageSync :
 never;
 
-type StorageAreaValues<Area extends StorageAreaName> =
+export type StorageAreaValues<Area extends StorageAreaName> =
 	Area extends "session" ? StorageSessionValues :
 	Area extends "local" ? StorageLocalValues :
 	Area extends "sync" ? StorageSyncValues :
 never;
 
-enum StorageSession { // Keys assumed to be unique across all storage areas (excluding 'managed')
+export enum StorageSession { // Keys assumed to be unique across all storage areas (excluding 'managed')
 	RESEARCH_INSTANCES = "researchInstances",
 	ENGINES = "engines",
 }
 
-enum StorageLocal {
+export enum StorageLocal {
 	ENABLED = "enabled",
 	PERSIST_RESEARCH_INSTANCES = "persistResearchInstances",
 }
 
-enum StorageSync {
+export enum StorageSync {
 	AUTO_FIND_OPTIONS = "autoFindOptions",
 	MATCH_MODE_DEFAULTS = "matchModeDefaults",
 	SHOW_HIGHLIGHTS = "showHighlights",
@@ -105,7 +109,7 @@ enum StorageSync {
 	TERM_LISTS = "termLists",
 }
 
-interface ResearchInstance {
+export interface ResearchInstance {
 	terms: MatchTerms
 	highlightsShown: boolean
 	barCollapsed: boolean
@@ -116,7 +120,7 @@ interface ResearchInstance {
  * The default options to be used for items missing from storage, or to which items may be reset.
  * Set to sensible options for a generic first-time user of the extension.
  */
-const optionsDefault: StorageSyncValues = {
+export const optionsDefault: StorageSyncValues = {
 	autoFindOptions: {
 		searchParams: [ // Order of specificity, as only the first match will be used.
 			"search_terms", "search_term", "searchTerms", "searchTerm",
@@ -199,7 +203,7 @@ const storageCache: Record<StorageAreaName, StorageAreaValues<StorageAreaName> |
  * @param keys The keys corresponding to the entries to retrieve.
  * @returns A promise resolving to an object of storage entries.
  */
-const storageGet = async <Area extends StorageAreaName>(area: Area, keys?: Array<StorageArea<Area>>):
+export const storageGet = async <Area extends StorageAreaName>(area: Area, keys?: Array<StorageArea<Area>>):
 	Promise<StorageAreaValues<Area>> =>
 {
 	if (keys && keys.every(key => storageCache[area][key as string] !== undefined)) {
@@ -222,7 +226,7 @@ const storageGet = async <Area extends StorageAreaName>(area: Area, keys?: Array
  * @param area 
  * @param store 
  */
-const storageSet = async <Area extends StorageAreaName>(area: Area, store: StorageAreaValues<Area>) => {
+export const storageSet = async <Area extends StorageAreaName>(area: Area, store: StorageAreaValues<Area>) => {
 	Object.entries(store).forEach(([ key, value ]) => {
 		storageCache[area][key] = value;
 	});
@@ -232,8 +236,7 @@ const storageSet = async <Area extends StorageAreaName>(area: Area, store: Stora
 /**
  * Sets internal storage to its default working values.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const storageInitialize = async () => {
+export const storageInitialize = async () => {
 	const local = await storageGet("local");
 	const localOld = { ...local };
 	const toRemove: Array<string> = [];
@@ -301,8 +304,7 @@ const objectFixWithDefaults = (
 /**
  * Checks persistent options storage for unwanted or misconfigured values, then restores it to a normal state.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const optionsRepair = async () => {
+export const optionsRepair = async () => {
 	const sync = await storageGet("sync");
 	const syncOld = { ...sync };
 	const toRemove = [];

--- a/src/pages/options.mts
+++ b/src/pages/options.mts
@@ -4,6 +4,10 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
+import { getIdSequential } from "/dist/modules/utility.mjs";
+import type { StorageSyncValues } from "/dist/modules/storage.mjs";
+import { optionsDefault, storageGet, storageSet } from "/dist/modules/storage.mjs";
+
 type OptionsInfo = Array<{
 	label: string
 	options: Partial<Record<keyof StorageSyncValues, {

--- a/src/pages/popup-build.mts
+++ b/src/pages/popup-build.mts
@@ -4,6 +4,14 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
+import type { MatchMode } from "/dist/modules/utility.mjs";
+import { MatchTerm, messageSendBackground } from "/dist/modules/utility.mjs";
+import { isTabResearchPage } from "/dist/modules/util-privileged.mjs";
+import type { PagePanelInfo, PageInteractionObjectRowInfo, PageInteractionCheckboxInfo } from "/dist/modules/page-build.mjs";
+import { loadPage, pageInsertWarning, sendProblemReport, PageAlertType } from "/dist/modules/page-build.mjs";
+import type { StorageLocalValues, StorageAreaName, StorageArea } from "/dist/modules/storage.mjs";
+import { StorageSession, StorageLocal, StorageSync, storageGet, storageSet } from "/dist/modules/storage.mjs";
+
 /**
  * Loads the popup content into the page.
  * This presents the user with common options and actions (usually those needed while navigating), to be placed in a popup.

--- a/src/pages/sendoff-build.mts
+++ b/src/pages/sendoff-build.mts
@@ -4,6 +4,10 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
+import { getName } from "/dist/modules/utility.mjs";
+import type { PagePanelInfo } from "/dist/modules/page-build.mjs";
+import { loadPage, sendProblemReport, PageAlertType } from "/dist/modules/page-build.mjs";
+
 /**
  * Loads the sendoff page content into the page.
  * This presents the user with an offboarding form with detail, for use when the user has uninstalled the extension.

--- a/src/pages/startpage-build.mts
+++ b/src/pages/startpage-build.mts
@@ -4,6 +4,12 @@
  * Licensed under the EUPL-1.2-or-later.
  */
 
+import { getName } from "/dist/modules/utility.mjs";
+import type { PagePanelInfo } from "/dist/modules/page-build.mjs";
+import { loadPage } from "/dist/modules/page-build.mjs";
+import type { StorageLocalValues } from "/dist/modules/storage.mjs";
+import { StorageLocal, storageGet, storageSet } from "/dist/modules/storage.mjs";
+
 /**
  * Loads the startpage content into the page.
  * This presents the user with expandable onboarding information and functions, for use when the user has installed the extension.


### PR DESCRIPTION
ES modules are used by 2.0. By converting the 1.X files to use them too, it becomes possible to backport changes from 2.0 and bring them to users sooner.